### PR TITLE
fix: Revert "Cleanup TODO (#8022)"

### DIFF
--- a/pkg/component/etcd/bootstrap.go
+++ b/pkg/component/etcd/bootstrap.go
@@ -16,6 +16,7 @@ package etcd
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"strconv"
 	"time"
@@ -67,6 +68,13 @@ const (
 	druidConfigMapImageVectorOverwriteDataKey          = "images_overwrite.yaml"
 	druidDeploymentVolumeMountPathImageVectorOverwrite = "/charts_overwrite"
 	druidDeploymentVolumeNameImageVectorOverwrite      = "imagevector-overwrite"
+)
+
+var (
+	//go:embed crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
+	etcdCRD string
+	//go:embed crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
+	etcdCopyBackupsTaskCRD1 string
 )
 
 // NewBootstrapper creates a new instance of DeployWaiter for the etcd bootstrapper.
@@ -362,6 +370,10 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// TODO(acumino): Drop CRDs deployment from here in release v1.73.
+	resources["crd.yaml"] = []byte(etcdCRD)
+	resources["crdEtcdCopyBackupsTask.yaml"] = []byte(etcdCopyBackupsTaskCRD1)
 
 	return managedresources.CreateForSeed(ctx, b.client, b.namespace, managedResourceControlName, false, resources)
 }

--- a/pkg/component/etcd/bootstrap_test.go
+++ b/pkg/component/etcd/bootstrap_test.go
@@ -16,6 +16,7 @@ package etcd_test
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"time"
 
@@ -42,6 +43,13 @@ import (
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var (
+	//go:embed crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
+	etcdCRD string
+	//go:embed crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
+	etcdCopyBackupsTaskCRD1 string
 )
 
 var _ = Describe("Etcd", func() {
@@ -471,6 +479,8 @@ status:
 					"verticalpodautoscaler__" + namespace + "__etcd-druid-vpa.yaml": []byte(vpaYAML),
 					"deployment__" + namespace + "__etcd-druid.yaml":                []byte(deploymentWithoutImageVectorOverwriteYAML),
 					"poddisruptionbudget__" + namespace + "__etcd-druid.yaml":       []byte(podDisruptionYAML),
+					"crd.yaml":                    []byte(etcdCRD),
+					"crdEtcdCopyBackupsTask.yaml": []byte(etcdCopyBackupsTaskCRD1),
 				},
 			}
 			managedResource = &resourcesv1alpha1.ManagedResource{

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcdcopybackupstasks-copy.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdcopybackupstasks.druid.gardener.cloud
+  annotations:
+    resources.gardener.cloud/mode: Ignore

--- a/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
+++ b/pkg/component/etcd/crds/templates/crd-druid.gardener.cloud_etcds-copy.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: etcds.druid.gardener.cloud
+  annotations:
+    resources.gardener.cloud/mode: Ignore


### PR DESCRIPTION
**How to categorize this PR?**

We will keep the migration code for our gardener release that ensures that the migration of the etcd CRDs from a `ManagedResource` to directly applied code happens without actually deleting the CRDs. Because we don't use v1.72 as a stepping stone

**What this PR does / why we need it**:

Required as we don't use v1.72

**Which issue(s) this PR fixes**:
Fixes Removal of CRD by MR

**Special notes for your reviewer**:

* Workaround removed in https://github.com/gardener/gardener/pull/8022
* Changes introduced in https://github.com/gardener/gardener/pull/8002

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
