### PR TITLE
fix gardener not setting ErrorCode on infra error

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 
-	extensionsworkerhelper "github.com/gardener/gardener/extensions/pkg/controller/worker/helper"
-	"github.com/gardener/gardener/extensions/pkg/util"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -31,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	extensionsworkerhelper "github.com/gardener/gardener/extensions/pkg/controller/worker/helper"
+	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	extensionsworkerhelper "github.com/gardener/gardener/extensions/pkg/controller/worker/helper"
+	"github.com/gardener/gardener/extensions/pkg/util"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -101,7 +103,11 @@ func (a *genericActuator) Delete(ctx context.Context, log logr.Logger, worker *e
 
 	// Wait until all machine resources have been properly deleted.
 	if err := a.waitUntilMachineResourcesDeleted(ctx, log, worker, workerDelegate); err != nil {
-		return fmt.Errorf("Failed while waiting for all machine resources to be deleted: %w", err)
+		//TODO(nschad): The following 2 lines become obsolete and wrong after Gardener v1.76+ and openstack-extension v1.37+
+		// SEE: https://dev.azure.com/schwarzit/schwarzit.ske/_workitems/edit/536673
+		newError := fmt.Errorf("Failed while waiting for all machine resources to be deleted: %w", err)
+		newError = util.DetermineError(newError, extensionsworkerhelper.KnownCodes)
+		return newError
 	}
 
 	// Wait until the machine class credentials secret has been released.

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gardener/gardener/extensions/pkg/util"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -159,9 +160,14 @@ func (a *genericActuator) Reconcile(ctx context.Context, log logr.Logger, worker
 				}
 			}
 			log.Info("Successfully deleted stuck machine-controller-manager pod", "reason", msg)
+
 		}
 
-		return fmt.Errorf("Failed while waiting for all machine deployments to be ready: %w", err)
+		//TODO(nschad): The following 2 lines become obsolete and wrong after Gardener v1.76+ and openstack-extension v1.37+
+		// SEE: https://dev.azure.com/schwarzit/schwarzit.ske/_workitems/edit/536673
+		newError := fmt.Errorf("Failed while waiting for all machine deployments to be ready: %w", err)
+		newError = util.DetermineError(newError, extensionsworkerhelper.KnownCodes)
+		return newError
 	}
 
 	// Delete all old machine deployments (i.e. those which were not previously computed but exist in the cluster).

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gardener/gardener/extensions/pkg/util"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +32,7 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsworkercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
 	extensionsworkerhelper "github.com/gardener/gardener/extensions/pkg/controller/worker/helper"
+	"github.com/gardener/gardener/extensions/pkg/util"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"

--- a/extensions/pkg/controller/worker/helper/helper.go
+++ b/extensions/pkg/controller/worker/helper/helper.go
@@ -16,8 +16,10 @@ package helper
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/hashicorp/go-multierror"
 
@@ -30,6 +32,33 @@ const (
 	MachineSetKind = "MachineSet"
 	// MachineDeploymentKind is the kind of the owner reference of a machine deployment
 	MachineDeploymentKind = "MachineDeployment"
+)
+
+// TODO(nschad): Remove with Gardner v1.76+
+// SEE: https://dev.azure.com/schwarzit/schwarzit.ske/_workitems/edit/536673
+var (
+	unauthenticatedRegexp               = regexp.MustCompile(`(?i)(Authentication failed|invalid character|invalid_client|cannot fetch token|InvalidSecretAccessKey)`)
+	unauthorizedRegexp                  = regexp.MustCompile(`(?i)(Unauthorized|SignatureDoesNotMatch|invalid_grant|Authorization Profile was not found|no active subscriptions|not authorized|AccessDenied|PolicyNotAuthorized)`)
+	quotaExceededRegexp                 = regexp.MustCompile(`(?i)((?:^|[^t]|(?:[^s]|^)t|(?:[^e]|^)st|(?:[^u]|^)est|(?:[^q]|^)uest|(?:[^e]|^)quest|(?:[^r]|^)equest)LimitExceeded|Quotas|Quota.*exceeded|exceeded quota|Quota has been met|QUOTA_EXCEEDED|Maximum number of ports exceeded|VolumeSizeExceedsAvailableQuota)`)
+	rateLimitsExceededRegexp            = regexp.MustCompile(`(?i)(RequestLimitExceeded|Throttling|Too many requests)`)
+	dependenciesRegexp                  = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|Conflict|inactive billing state|timeout while waiting for state to become|InvalidCidrBlock|already busy for|internal server error|A resource with the ID|There are not enough hosts available)`)
+	retryableDependenciesRegexp         = regexp.MustCompile(`(?i)(RetryableError)`)
+	resourcesDepletedRegexp             = regexp.MustCompile(`(?i)(not available in the current hardware cluster|out of stock)`)
+	configurationProblemRegexp          = regexp.MustCompile(`(?i)(not supported in your requested Availability Zone|notFound|Invalid value|violates constraint|no attached internet gateway found|Your query returned no results|invalid VPC attributes|unrecognized feature gate|runtime-config invalid key|strict decoder error|not allowed to configure an unsupported|error during apply of object .* is invalid:|duplicate zones|overlapping zones)`)
+	retryableConfigurationProblemRegexp = regexp.MustCompile(`(?i)(is misconfigured and requires zero voluntary evictions|SDK.CanNotResolveEndpoint|The requested configuration is currently not supported)`)
+
+	// KnownCodes maps Gardener error codes to respective regex.
+	KnownCodes = map[gardencorev1beta1.ErrorCode]func(string) bool{
+		gardencorev1beta1.ErrorInfraUnauthenticated:          unauthenticatedRegexp.MatchString,
+		gardencorev1beta1.ErrorInfraUnauthorized:             unauthorizedRegexp.MatchString,
+		gardencorev1beta1.ErrorInfraQuotaExceeded:            quotaExceededRegexp.MatchString,
+		gardencorev1beta1.ErrorInfraRateLimitsExceeded:       rateLimitsExceededRegexp.MatchString,
+		gardencorev1beta1.ErrorInfraDependencies:             dependenciesRegexp.MatchString,
+		gardencorev1beta1.ErrorRetryableInfraDependencies:    retryableDependenciesRegexp.MatchString,
+		gardencorev1beta1.ErrorInfraResourcesDepleted:        resourcesDepletedRegexp.MatchString,
+		gardencorev1beta1.ErrorConfigurationProblem:          configurationProblemRegexp.MatchString,
+		gardencorev1beta1.ErrorRetryableConfigurationProblem: retryableConfigurationProblemRegexp.MatchString,
+	}
 )
 
 // BuildOwnerToMachinesMap builds a map from a slice of machinev1alpha1.Machine, that maps the owner reference

--- a/extensions/pkg/controller/worker/helper/helper.go
+++ b/extensions/pkg/controller/worker/helper/helper.go
@@ -19,10 +19,10 @@ import (
 	"regexp"
 	"strings"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/hashicorp/go-multierror"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	errorsutils "github.com/gardener/gardener/pkg/utils/errors"
 )
 

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -478,11 +478,11 @@ func (h *Health) checkClusterNodes(
 	condition gardencorev1beta1.Condition,
 	extensionConditions []ExtensionCondition,
 ) (*gardencorev1beta1.Condition, error) {
-	if exitCondition, err := checker.CheckClusterNodes(ctx, shootClient, seedNamespace, h.shoot.GetInfo().Spec.Provider.Workers, condition); err != nil || exitCondition != nil {
-		return exitCondition, err
-	}
 	if exitCondition := checker.CheckExtensionCondition(condition, extensionConditions); exitCondition != nil {
 		return exitCondition, nil
+	}
+	if exitCondition, err := checker.CheckClusterNodes(ctx, shootClient, seedNamespace, h.shoot.GetInfo().Spec.Provider.Workers, condition); err != nil || exitCondition != nil {
+		return exitCondition, err
 	}
 
 	c := v1beta1helper.UpdatedConditionWithClock(h.clock, condition, gardencorev1beta1.ConditionTrue, "EveryNodeReady", "All nodes are ready.")


### PR DESCRIPTION
**How to categorize this PR?**
/area ops-productivity
/kind regression
/hold wait-for-testing

**What this PR does / why we need it**:
In Gardener 1.76 the `Generic_Actuator` gets an errCodeFunction which becomes aware of any provider errors. Before this gardener version this do not happen. Somewhere in the rework of the error detection something wasn't implemented correctly or got lost. It's unclear as to specific what but once we have atleast gardener 1.76+ the funtionality should become available again.

The openstack extension is aware of the errCodeFunction since v1.37

This PR hotfixxes the missing errCodeFunction directly into gardener/gardener instead of being implemented by the extension. Therefore we must remove later-on.

**This PR is not mergable upstream.**

**Which issue(s) this PR fixes**:
[Fixes #536673](https://dev.azure.com/schwarzit/schwarzit.ske/_workitems/edit/536673)

**Special notes for your reviewer**:
Concourse Build Job: [#Job..](https://concourse.ske.eu01.stackit.cloud/teams/main/pipelines/gardener-component/jobs/feature/builds/1?vars.branch=%22fix%2Ferror-code%22)
