### PR TITLE
Remove vali check for Seed Health

### DIFF
--- a/pkg/operation/care/seed_health.go
+++ b/pkg/operation/care/seed_health.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gardener/gardener/pkg/component/istio"
 	"github.com/gardener/gardener/pkg/component/kubestatemetrics"
 	"github.com/gardener/gardener/pkg/component/logging/fluentoperator"
-	"github.com/gardener/gardener/pkg/component/logging/vali"
 	"github.com/gardener/gardener/pkg/component/nginxingress"
 	"github.com/gardener/gardener/pkg/component/seedsystem"
 	"github.com/gardener/gardener/pkg/component/vpa"
@@ -128,7 +127,6 @@ func (h *SeedHealth) checkSeedSystemComponents(
 		managedResources = append(managedResources, fluentoperator.OperatorManagedResourceName)
 		managedResources = append(managedResources, fluentoperator.CustomResourcesManagedResourceName)
 		managedResources = append(managedResources, fluentoperator.FluentBitManagedResourceName)
-		managedResources = append(managedResources, vali.ManagedResourceNameRuntime)
 	}
 
 	for _, name := range managedResources {


### PR DESCRIPTION
This can be removed with gardener v1.85.0

**How to categorize this PR?**
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/8240/files#diff-ca1fef8bef9452102c66af817d137a2bd5dbcaf2368d4cf0983c0f208b99ecedR130 added the vali managed resources to the health checks of a seed. Since we explicitly disable vail in the gardenlet values https://github.com/stackitcloud/ske-base/blob/main/base/installer/config/gardenlet-values-0.yaml#L95 this can never work.

In https://github.com/gardener/gardener/pull/8387 (v1.79.0) the care package was refactored and the change needs to be applied to `pkg/gardenlet/controller/seed/care/health.go` instead
This is later fixed in https://github.com/gardener/gardener/pull/8840, so with g/g 1.85.x this commit can be dropped.

**Which issue(s) this PR fixes**:
Allows us to use g/g 1.77

