### PR TITLE
resourcemanager: do not fail if hvpa CRD is not deployed

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -63,6 +63,7 @@ import (
 	resourcemanagerpredicate "github.com/gardener/gardener/pkg/resourcemanager/predicate"
 	errorsutils "github.com/gardener/gardener/pkg/utils/errors"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/third_party/controller-runtime/pkg/apiutil"
 )
 
 var (
@@ -566,7 +567,7 @@ func computeAllScaledObjectKeys(ctx context.Context, c client.Client) (horizonta
 
 	// get all HVPAs' targets
 	hvpaList := &hvpav1alpha1.HvpaList{}
-	if err := c.List(ctx, hvpaList); err != nil && !meta.IsNoMatchError(err) {
+	if err := c.List(ctx, hvpaList); err != nil && !apiutil.IsNoMatchError(err) {
 		return horizontallyScaledObjects, verticallyScaledObjects, fmt.Errorf("failed to list all HVPAs: %w", err)
 	}
 

--- a/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
+++ b/pkg/resourcemanager/webhook/highavailabilityconfig/handler.go
@@ -32,7 +32,6 @@ import (
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -46,6 +45,7 @@ import (
 	"github.com/gardener/gardener/pkg/resourcemanager/apis/config"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
+	"github.com/gardener/gardener/third_party/controller-runtime/pkg/apiutil"
 )
 
 // Handler handles admission requests and sets the following fields based on the failure tolerance type and the
@@ -381,7 +381,7 @@ func (h *Handler) isHorizontallyScaled(ctx context.Context, namespace, targetAPI
 	}
 
 	hvpaList := &hvpav1alpha1.HvpaList{}
-	if err := h.TargetClient.List(ctx, hvpaList); err != nil && !meta.IsNoMatchError(err) {
+	if err := h.TargetClient.List(ctx, hvpaList); err != nil && !apiutil.IsNoMatchError(err) {
 		return false, 0, fmt.Errorf("failed to list all HVPAs: %w", err)
 	}
 

--- a/third_party/controller-runtime/pkg/apiutil/lazyrestmapper.go
+++ b/third_party/controller-runtime/pkg/apiutil/lazyrestmapper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiutil
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -263,4 +264,13 @@ func (m *lazyRESTMapper) fetchGroupVersionResources(groupName string, versions .
 	}
 
 	return groupVersionResources, nil
+}
+
+func IsNoMatchError(err error) bool {
+	if meta.IsNoMatchError(err) {
+		return true
+	}
+
+	var gd *discovery.ErrGroupDiscoveryFailed
+	return errors.As(err, &gd)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:

do not fail if hvpa CRD is not deployed.

After upgrading to 1.79 all seeds became stuck in `[task "sync StatefulSet task" failed: admission webhook "high-availability-config.resources.gardener.cloud" denied the request: failed to list all HVPAs: failed to get API group resources: unable to retrieve the complete list of server APIs: autoscaling.k8s.io/v1alpha1: the server could not find the requested resource])`.


**Which issue(s) this PR fixes**:
Replaces #47 as that branch used the wrong base commit.

**Special notes for your reviewer**:
