### PR TITLE
Fix unrecoverable issues with `etcd` during credentials rotation (#8795)

### DIFF
--- a/pkg/component/etcd/etcd.go
+++ b/pkg/component/etcd/etcd.go
@@ -694,13 +694,7 @@ func (e *etcd) RolloutPeerCA(ctx context.Context) error {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCDPeer)
 	}
 
-	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, e.etcd, func() error {
-		// Exit early if etcd object has already the expected CA reference.
-		if peerTLS := e.etcd.Spec.Etcd.PeerUrlTLS; peerTLS != nil &&
-			peerTLS.TLSCASecretRef.Name == etcdPeerCASecret.Name {
-			return nil
-		}
-
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, e.etcd, func() error {
 		e.etcd.Annotations = map[string]string{
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 			v1beta1constants.GardenerTimestamp: TimeNow().UTC().Format(time.RFC3339Nano),
@@ -723,8 +717,11 @@ func (e *etcd) RolloutPeerCA(ctx context.Context) error {
 			DataKey: dataKey,
 		}
 		return nil
-	})
-	return err
+	}); err != nil {
+		return err
+	}
+
+	return e.Wait(ctx)
 }
 
 func (e *etcd) GetValues() Values { return e.values }

--- a/pkg/component/etcd/etcd_test.go
+++ b/pkg/component/etcd/etcd_test.go
@@ -1761,8 +1761,9 @@ var _ = Describe("Etcd", func() {
 			createEtcdObj := func(caName string) *druidv1alpha1.Etcd {
 				return &druidv1alpha1.Etcd{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      etcdName,
-						Namespace: testNamespace,
+						Name:       etcdName,
+						Namespace:  testNamespace,
+						Generation: 1,
 					},
 					Spec: druidv1alpha1.EtcdSpec{
 						Etcd: druidv1alpha1.EtcdConfig{
@@ -1776,6 +1777,10 @@ var _ = Describe("Etcd", func() {
 								},
 							},
 						},
+					},
+					Status: druidv1alpha1.EtcdStatus{
+						ObservedGeneration: pointer.Int64(1),
+						Ready:              pointer.Bool(true),
 					},
 				}
 			}
@@ -1801,10 +1806,16 @@ var _ = Describe("Etcd", func() {
 						return nil
 					})
 
+				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					createEtcdObj("old-ca").DeepCopyInto(obj.(*druidv1alpha1.Etcd))
+					obj.(*druidv1alpha1.Etcd).ObjectMeta.Annotations = map[string]string{"gardener.cloud/timestamp": "0001-01-01T00:00:00Z"}
+					return nil
+				}).AnyTimes()
+
 				Expect(etcd.RolloutPeerCA(ctx)).To(Succeed())
 			})
 
-			It("should not patch anything because the expected CA ref is already configured", func() {
+			It("should only patch reconcile annotation data because the expected CA ref is already configured", func() {
 				peerCAName := "ca-etcd-peer"
 
 				Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: peerCAName, Namespace: testNamespace}})).To(Succeed())
@@ -1818,9 +1829,15 @@ var _ = Describe("Etcd", func() {
 					func(_ context.Context, obj *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
 						data, err := patch.Data(obj)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(data).To(MatchJSON("{}"))
+						Expect(data).To(MatchJSON("{\"metadata\":{\"annotations\":{\"gardener.cloud/operation\":\"reconcile\",\"gardener.cloud/timestamp\":\"0001-01-01T00:00:00Z\"}}}"))
 						return nil
 					})
+
+				c.EXPECT().Get(gomock.Any(), kubernetesutils.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					createEtcdObj(peerCAName).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
+					obj.(*druidv1alpha1.Etcd).ObjectMeta.Annotations = map[string]string{"gardener.cloud/timestamp": "0001-01-01T00:00:00Z"}
+					return nil
+				}).AnyTimes()
 
 				Expect(etcd.RolloutPeerCA(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -133,10 +133,6 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 		)(ctx); err != nil {
 			return err
 		}
-
-		if err := b.WaitUntilEtcdsReady(ctx); err != nil {
-			return err
-		}
 	}
 
 	return flow.Parallel(

--- a/pkg/operator/controller/garden/garden/reconciler_reconcile.go
+++ b/pkg/operator/controller/garden/garden/reconciler_reconcile.go
@@ -473,9 +473,9 @@ func (r *Reconciler) deployEtcdsFunc(garden *operatorv1alpha1.Garden, etcdMain, 
 		// This is required because peer certificates which are used for client and server authentication at the same time,
 		// are re-created with the new CA in the `Deploy` step.
 		if helper.GetCARotationPhase(garden.Status.Credentials) == gardencorev1beta1.RotationPreparing {
-			if err := flow.Sequential(
-				flow.Parallel(etcdMain.RolloutPeerCA, etcdEvents.RolloutPeerCA),
-				flow.Parallel(etcdMain.Wait, etcdEvents.Wait),
+			if err := flow.Parallel(
+				etcdMain.RolloutPeerCA,
+				etcdEvents.RolloutPeerCA,
 			)(ctx); err != nil {
 				return err
 			}


### PR DESCRIPTION
/kind enhancement

Cherrypick of https://github.com/gardener/gardener/pull/8795. This fixes (most) cases of stuck credentials rotations.

The cherry-picked changes are part of Gardener 1.84 and can be removed once we reach that version.