### PR TITLE
[ske-v1.86] Cherry-pick apiserver-proxy changes

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -18,25 +18,26 @@ The following tables are a summary of the feature gates that you can set on diff
 
 ## Feature Gates for Alpha or Beta Features
 
-| Feature                             | Default | Stage   | Since  | Until  |
-|-------------------------------------|---------|---------|--------|--------|
-| HVPA                                | `false` | `Alpha` | `0.31` |        |
-| HVPAForShootedSeed                  | `false` | `Alpha` | `0.32` |        |
-| DefaultSeccompProfile               | `false` | `Alpha` | `1.54` |        |
-| CoreDNSQueryRewriting               | `false` | `Alpha` | `1.55` |        |
-| IPv6SingleStack                     | `false` | `Alpha` | `1.63` |        |
-| MutableShootSpecNetworkingNodes     | `false` | `Alpha` | `1.64` |        |
-| WorkerlessShoots                    | `false` | `Alpha` | `1.70` | `1.78` |
-| WorkerlessShoots                    | `false` | `Beta`  | `1.79` | `1.85` |
-| WorkerlessShoots                    | `true`  | `GA`    | `1.86` |        |
-| MachineControllerManagerDeployment  | `false` | `Alpha` | `1.73` |        |
-| MachineControllerManagerDeployment  | `true`  | `Beta`  | `1.81` | `1.81` |
-| MachineControllerManagerDeployment  | `true`  | `GA`    | `1.82` |        |
-| ContainerdRegistryHostsDir          | `false` | `Alpha` | `1.77` | `1.85` |
-| ContainerdRegistryHostsDir          | `false` | `Beta`  | `1.86` |        |
-| ShootForceDeletion                  | `false` | `Alpha` | `1.81` |        |
-| APIServerFastRollout                | `true`  | `Beta`  | `1.82` |        |
-| UseGardenerNodeAgent                | `false` | `Alpha` | `1.82` |        |
+| Feature                            | Default | Stage   | Since  | Until  |
+|------------------------------------|---------|---------|--------|--------|
+| HVPA                               | `false` | `Alpha` | `0.31` |        |
+| HVPAForShootedSeed                 | `false` | `Alpha` | `0.32` |        |
+| DefaultSeccompProfile              | `false` | `Alpha` | `1.54` |        |
+| CoreDNSQueryRewriting              | `false` | `Alpha` | `1.55` |        |
+| IPv6SingleStack                    | `false` | `Alpha` | `1.63` |        |
+| MutableShootSpecNetworkingNodes    | `false` | `Alpha` | `1.64` |        |
+| WorkerlessShoots                   | `false` | `Alpha` | `1.70` | `1.78` |
+| WorkerlessShoots                   | `false` | `Beta`  | `1.79` | `1.85` |
+| WorkerlessShoots                   | `true`  | `GA`    | `1.86` |        |
+| MachineControllerManagerDeployment | `false` | `Alpha` | `1.73` |        |
+| MachineControllerManagerDeployment | `true`  | `Beta`  | `1.81` | `1.81` |
+| MachineControllerManagerDeployment | `true`  | `GA`    | `1.82` |        |
+| ContainerdRegistryHostsDir         | `false` | `Alpha` | `1.77` | `1.85` |
+| ContainerdRegistryHostsDir         | `false` | `Beta`  | `1.86` |        |
+| ShootForceDeletion                 | `false` | `Alpha` | `1.81` |        |
+| APIServerFastRollout               | `true`  | `Beta`  | `1.82` |        |
+| UseGardenerNodeAgent               | `false` | `Alpha` | `1.82` |        |
+| DisableAPIServerProxyPort          | `false` | `Alpha` | `1.96` |        |
 
 ## Feature Gates for Graduated or Deprecated Features
 
@@ -189,5 +190,5 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | MachineControllerManagerDeployment | `gardenlet`                       | Enables Gardener to take over the deployment of the machine-controller-manager. If enabled, all registered provider extensions must support injecting the provider-specific MCM sidecar container into the deployment via the `controlplane` webhook.                                                                                                                              |
 | ContainerdRegistryHostsDir         | `gardenlet`                       | Enables registry configuration in containerd based on the hosts directory pattern. The hosts directory pattern is the new way of configuring registries/mirrors in containerd. Ref https://github.com/containerd/containerd/blob/main/docs/hosts.md.                                                                                                                               |
 | ShootForceDeletion                 | `gardener-apiserver`              | Allows forceful deletion of Shoots by annotating them with the `confirmation.gardener.cloud/force-deletion` annotation.                                                                                                                                                                                                                                                            |
-| APIServerFastRollout               | `gardenlet`                       | Enables fast rollouts for Shoot kube-apiservers on the given Seed. When enabled, `maxSurge` for Shoot kube-apiserver deployments is set to 100%.                                                                                                                                                                                                                                                                  |
-| UseGardenerNodeAgent               | `gardenlet`                       | Enables the `gardener-node-agent` instead of the `cloud-config-downloader` for shoot worker nodes.                                                                                                                                                                                                                                                                                 |
+| APIServerFastRollout               | `gardenlet`                       | Enables fast rollouts for Shoot kube-apiservers on the given Seed. When enabled, `maxSurge` for Shoot kube-apiserver deployments is set to 100%.                                                                                                                                                                                                                                   |
+| UseGardenerNodeAgent               | `gardenlet`                       | Enables the `gardener-node-agent` instead of the `cloud-config-downloader` for shoot worker nodes.                                                                                                                                                                                                                                                                                 || DisableAPIServerProxyPort       | `gardenlet`                       | Disables the proxy port (8443) on the istio-ingressgateway Services. It was previously used by the apiserver-proxy to route client traffic on the kubernetes Service to the corresponding API server using the TCP proxy protocol. As soon as a shoot has been reconciled by gardener v1.96+, the apiserver-proxy is reconfigured to use HTTP CONNECT on the tls-tunnel port (8132) instead, i.e., it reuses the reversed VPN path to connect to the correct API server. Operators can choose to remove the legacy apiserver-proxy port as soon as all shoots have switched to the new apiserver-proxy configuration. They might want to do so if they activate the ACL extension, which is vulnerable to proxy protocol headers of untrusted clients on the apiserver-proxy port. |

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -638,8 +638,9 @@ images:
 # External Authorization Server for the Istio Endpoint of Reversed VPN
 - name: ext-authz-server
   sourceRepository: github.com/gardener/ext-authz-server
-  repository: eu.gcr.io/gardener-project/gardener/ext-authz-server
-  tag: "0.9.0"
+  # built from https://github.com/stackitcloud/ext-authz-server/tree/hackathon-apiserver-proxy
+  repository: ghcr.io/stackitcloud/ext-authz-server
+  tag: "0.10.0-dev-34b23c6"
 
 # API Server SNI
 - name: apiserver-proxy

--- a/pkg/component/apiserverproxy/apiserver_proxy.go
+++ b/pkg/component/apiserverproxy/apiserver_proxy.go
@@ -37,6 +37,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -53,7 +54,7 @@ const (
 	webhookExpressionsKey = "apiserver-proxy.networking.gardener.cloud/inject"
 
 	adminPort           = 16910
-	proxySeedServerPort = 8443
+	proxySeedServerPort = vpnseedserver.GatewayPort
 
 	volumeNameConfig   = "proxy-config"
 	volumeNameAdminUDS = "admin-uds"
@@ -165,6 +166,7 @@ func (a *apiserverProxy) computeResourcesData() (map[string][]byte, error) {
 		"adminPort":           adminPort,
 		"proxySeedServerHost": a.values.ProxySeedServerHost,
 		"proxySeedServerPort": proxySeedServerPort,
+		"namespace":           a.namespace,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/component/apiserverproxy/apiserver_proxy_test.go
+++ b/pkg/component/apiserverproxy/apiserver_proxy_test.go
@@ -474,6 +474,12 @@ data:
               "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
               stat_prefix: kube_apiserver
               cluster: kube_apiserver
+              tunneling_config:
+                hostname: "api.internal.local.:443"
+                headers_to_add:
+                - header:
+                    key: Reversed-VPN
+                    value: "outbound|443||kube-apiserver.some-namespace.svc.cluster.local"
               access_log:
               - name: envoy.access_loggers.stdout
                 typed_config:
@@ -541,17 +547,7 @@ data:
                 address:
                   socket_address:
                     address: api.internal.local.
-                    port_value: 8443
-        transport_socket:
-          name: envoy.transport_sockets.upstream_proxy_protocol
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.transport_sockets.proxy_protocol.v3.ProxyProtocolUpstreamTransport
-            config:
-              version: V2
-            transport_socket:
-              name: envoy.transport_sockets.raw_buffer
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
+                    port_value: 8132
         upstream_connection_options:
           tcp_keepalive:
             keepalive_time: 7200

--- a/pkg/component/apiserverproxy/templates/envoy.yaml.tpl
+++ b/pkg/component/apiserverproxy/templates/envoy.yaml.tpl
@@ -51,6 +51,12 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
           stat_prefix: kube_apiserver
           cluster: kube_apiserver
+          tunneling_config:
+            hostname: "{{ .proxySeedServerHost }}:443"
+            headers_to_add:
+            - header:
+                key: Reversed-VPN
+                value: "outbound|443||kube-apiserver.{{ .namespace }}.svc.cluster.local"
           access_log:
           - name: envoy.access_loggers.stdout
             typed_config:
@@ -119,16 +125,6 @@ static_resources:
               socket_address:
                 address: {{ .proxySeedServerHost }}
                 port_value: {{ .proxySeedServerPort }}
-    transport_socket:
-      name: envoy.transport_sockets.upstream_proxy_protocol
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.proxy_protocol.v3.ProxyProtocolUpstreamTransport
-        config:
-          version: V2
-        transport_socket:
-          name: envoy.transport_sockets.raw_buffer
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
     upstream_connection_options:
       tcp_keepalive:
         keepalive_time: 7200

--- a/pkg/component/kubeapiserverexposure/kube_apiserver_sni.go
+++ b/pkg/component/kubeapiserverexposure/kube_apiserver_sni.go
@@ -147,6 +147,10 @@ func (s *sni) Deploy(ctx context.Context) error {
 		if err := s.applier.ApplyManifest(ctx, kubernetes.NewManifestReader(envoyFilterSpec.Bytes()), kubernetes.DefaultMergeFuncs); err != nil {
 			return err
 		}
+	} else {
+		if err := s.client.Delete(ctx, s.emptyEnvoyFilter()); client.IgnoreNotFound(err) != nil {
+			return err
+		}
 	}
 
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, s.client, destinationRule, func() error {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -109,6 +109,18 @@ const (
 	// owner: @rfranzke @oliver-goetz
 	// alpha: v1.82.0
 	UseGardenerNodeAgent featuregate.Feature = "UseGardenerNodeAgent"
+
+	// DisableAPIServerProxyPort disables the proxy port (8443) on the istio-ingressgateway Services. It was previously
+	// used by the apiserver-proxy to route client traffic on the kubernetes Service to the corresponding API server using
+	// the TCP proxy protocol.
+	// As soon as a shoot has been reconciled by gardener v1.96+, the apiserver-proxy is reconfigured to use HTTP CONNECT
+	// on the tls-tunnel port (8132) instead, i.e., it reuses the reversed VPN path to connect to the correct API server.
+	// Operators can choose to remove the legacy apiserver-proxy port as soon as all shoots have switched to the new
+	// apiserver-proxy configuration. They might want to do so if they activate the ACL extension, which is vulnerable to
+	// proxy protocol headers of untrusted clients on the apiserver-proxy port.
+	// owner: @timebertt
+	// alpha: v1.96.0
+	DisableAPIServerProxyPort = "DisableAPIServerProxyPort"
 )
 
 // DefaultFeatureGate is the central feature gate map used by all gardener components.
@@ -148,6 +160,7 @@ var AllFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ContainerdRegistryHostsDir:         {Default: true, PreRelease: featuregate.Beta},
 	APIServerFastRollout:               {Default: true, PreRelease: featuregate.Beta},
 	UseGardenerNodeAgent:               {Default: false, PreRelease: featuregate.Alpha},
+	DisableAPIServerProxyPort:          {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/gardenlet/controller/seed/seed/components.go
+++ b/pkg/gardenlet/controller/seed/seed/components.go
@@ -61,6 +61,7 @@ import (
 	"github.com/gardener/gardener/pkg/component/vpnauthzserver"
 	"github.com/gardener/gardener/pkg/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/component/vpnshoot"
+	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/utils"
@@ -86,6 +87,18 @@ func defaultIstio(
 		labels  = shared.GetIstioZoneLabels(conf.SNI.Ingress.Labels, nil)
 	)
 
+	ports := []corev1.ServicePort{
+		{Name: "tcp", Port: 443, TargetPort: intstr.FromInt32(9443)},
+		{Name: "tls-tunnel", Port: vpnseedserver.GatewayPort, TargetPort: intstr.FromInt32(vpnseedserver.GatewayPort)},
+	}
+
+	proxyProtocolEnabled := !features.DefaultFeatureGate.Enabled(features.DisableAPIServerProxyPort)
+	if proxyProtocolEnabled {
+		ports = append(ports, corev1.ServicePort{
+			Name: "proxy", Port: 8443, TargetPort: intstr.FromInt32(8443),
+		})
+	}
+
 	istioDeployer, err := shared.NewIstio(
 		seedClient,
 		chartRenderer,
@@ -98,12 +111,8 @@ func defaultIstio(
 		seed.GetLoadBalancerServiceAnnotations(),
 		seed.GetLoadBalancerServiceExternalTrafficPolicy(),
 		conf.SNI.Ingress.ServiceExternalIP,
-		[]corev1.ServicePort{
-			{Name: "proxy", Port: 8443, TargetPort: intstr.FromInt32(8443)},
-			{Name: "tcp", Port: 443, TargetPort: intstr.FromInt32(9443)},
-			{Name: "tls-tunnel", Port: vpnseedserver.GatewayPort, TargetPort: intstr.FromInt32(vpnseedserver.GatewayPort)},
-		},
-		true,
+		ports,
+		proxyProtocolEnabled,
 		true,
 		seedObj.Spec.Provider.Zones,
 	)

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -38,5 +38,6 @@ func GetFeatures() []featuregate.Feature {
 		features.ContainerdRegistryHostsDir,
 		features.APIServerFastRollout,
 		features.UseGardenerNodeAgent,
+		features.DisableAPIServerProxyPort,
 	}
 }

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -23,6 +23,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/component/kubeapiserverexposure"
+	"github.com/gardener/gardener/pkg/features"
 	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 )
 
@@ -86,7 +87,7 @@ func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
 		v1beta1constants.DeploymentNameKubeAPIServer,
 		b.Shoot.SeedNamespace,
 		func() *kubeapiserverexposure.SNIValues {
-			return &kubeapiserverexposure.SNIValues{
+			values := &kubeapiserverexposure.SNIValues{
 				Hosts: []string{
 					gardenerutils.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain),
 					gardenerutils.GetAPIServerDomain(b.Shoot.InternalClusterDomain),
@@ -100,6 +101,12 @@ func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
 					Labels:    b.IstioLabels(),
 				},
 			}
+
+			if features.DefaultFeatureGate.Enabled(features.DisableAPIServerProxyPort) {
+				values.APIServerProxy = nil
+			}
+
+			return values
 		},
 	)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:

Cherry-pick of https://github.com/stackitcloud/gardener/tree/hackathon-apiserver-proxy

TODO

**Which issue(s) this PR fixes**:
Part of [ADO#626304](https://dev.azure.com/schwarzit/schwarzit.ske/_workitems/edit/626304)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
