### PR TITLE
Allow changing the project creator of the "garden" project

### DIFF
--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -54,7 +54,7 @@ func ValidateProjectUpdate(newProject, oldProject *core.Project) field.ErrorList
 	if oldProject.Spec.CreatedBy != nil {
 		// allow mutating the creator of the garden project only for the gardener-operator migration
 		// TODO: drop this change after the migration from yake to gardener-operator
-		if !(oldProject.Name == "garden") {
+		if oldProject.Name != "garden" {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProject.Spec.CreatedBy, oldProject.Spec.CreatedBy, field.NewPath("spec", "createdBy"))...)
 		}
 	}

--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -52,7 +52,11 @@ func ValidateProjectUpdate(newProject, oldProject *core.Project) field.ErrorList
 	allErrs = append(allErrs, ValidateProject(newProject)...)
 
 	if oldProject.Spec.CreatedBy != nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProject.Spec.CreatedBy, oldProject.Spec.CreatedBy, field.NewPath("spec", "createdBy"))...)
+		// allow mutating the creator of the garden project only for the gardener-operator migration
+		// TODO: drop this change after the migration from yake to gardener-operator
+		if !(oldProject.Name == "garden") {
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProject.Spec.CreatedBy, oldProject.Spec.CreatedBy, field.NewPath("spec", "createdBy"))...)
+		}
 	}
 	if oldProject.Spec.Namespace != nil {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProject.Spec.Namespace, oldProject.Spec.Namespace, field.NewPath("spec", "namespace"))...)


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
During the gardener-operator migration, the `garden` namespaces creator will be changed, which is not allowed by the validation. We need to allow this change for the migration to work successfully.

**Which issue(s) this PR fixes**:
https://dev.azure.com/schwarzit/schwarzit.ske/_workitems/edit/647586

**Notes**
Im adding this to 1.91, as I assume we'll upgrade to that today.
@robinschneider this needs to be added to #82 as well.
