### PR TITLE
[v1.90] Omit useless data from `OperatingSystemConfig` in `Secret`s reconciled by `gardener-node-agent` (#9723)

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets.go
@@ -41,14 +41,17 @@ func OperatingSystemConfigSecret(
 	*corev1.Secret,
 	error,
 ) {
+	// This OperatingSystemConfig object should only contain the data relevant for gardener-node-agent reconciliation to
+	// prevent undesired changes of the computed checksum of this object.
 	operatingSystemConfig := &extensionsv1alpha1.OperatingSystemConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        osc.Name,
-			Labels:      osc.Labels,
-			Annotations: osc.Annotations,
+		Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+			Units: osc.Spec.Units,
+			Files: osc.Spec.Files,
 		},
-		Spec:   osc.Spec,
-		Status: osc.Status,
+		Status: extensionsv1alpha1.OperatingSystemConfigStatus{
+			ExtensionUnits: osc.Status.ExtensionUnits,
+			ExtensionFiles: osc.Status.ExtensionFiles,
+		},
 	}
 
 	// The OperatingSystemConfig will be deployed to the shoot to get processed by gardener-node-agent. It doesn't

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/secrets_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent"
@@ -89,6 +90,14 @@ var _ = Describe("Secrets", func() {
 					ExtensionUnits: []extensionsv1alpha1.Unit{{
 						Name: "some-other-unit.service",
 					}},
+					ExtensionFiles: []extensionsv1alpha1.File{{
+						Path: "/some/other/path",
+					}},
+					DefaultStatus: extensionsv1alpha1.DefaultStatus{
+						LastOperation: &gardencorev1beta1.LastOperation{
+							LastUpdateTime: metav1.Now(),
+						},
+					},
 				},
 			}
 		})
@@ -101,7 +110,7 @@ var _ = Describe("Secrets", func() {
 					Name:      secretName,
 					Namespace: "kube-system",
 					Annotations: map[string]string{
-						"checksum/data-script": "b0a0d190d45f0d67d97bf30d7e45d9cbbaa86bbe99f34bc095a6fd172d1a18a2",
+						"checksum/data-script": "931abcfaf3fd3152748ec51b8f139a22a48a3ac6d8fff1c56a3aa2e07d2a39f1",
 					},
 					Labels: map[string]string{
 						"gardener.cloud/role":        "operating-system-config",
@@ -111,12 +120,7 @@ var _ = Describe("Secrets", func() {
 				Data: map[string][]byte{"osc.yaml": []byte(`apiVersion: extensions.gardener.cloud/v1alpha1
 kind: OperatingSystemConfig
 metadata:
-  annotations:
-    bar: foo
   creationTimestamp: null
-  labels:
-    foo: bar
-  name: osc-name
 spec:
   files:
   - content:
@@ -129,6 +133,9 @@ spec:
   units:
   - name: some-unit.service
 status:
+  extensionFiles:
+  - content: {}
+    path: /some/other/path
   extensionUnits:
   - name: some-other-unit.service
 `)},


### PR DESCRIPTION
**How to categorize this PR?**

Backport https://github.com/gardener/gardener/pull/9723
This is not needed for G/G 1.92+ (already included)

**What this PR does / why we need it**:

Because, well the OSC Config is updated on every reconcile which is annoying and makes reconciles super long.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
