### PR TITLE
Collect garden condition metrics

### DIFF
--- a/cmd/gardener-operator/app/app.go
+++ b/cmd/gardener-operator/app/app.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gardener/gardener/pkg/operator/apis/config"
 	operatorclient "github.com/gardener/gardener/pkg/operator/client"
 	"github.com/gardener/gardener/pkg/operator/controller"
+	"github.com/gardener/gardener/pkg/operator/metrics"
 	"github.com/gardener/gardener/pkg/operator/webhook"
 )
 
@@ -183,6 +184,11 @@ func run(ctx context.Context, log logr.Logger, cfg *config.OperatorConfiguration
 	log.Info("Adding webhook handlers to manager")
 	if err := webhook.AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding webhook handlers to manager: %w", err)
+	}
+
+	log.Info("Adding custom metrics to manager")
+	if err := metrics.AddToManager(ctx, mgr); err != nil {
+		return fmt.Errorf("failed adding metrics to manager: %w", err)
 	}
 
 	log.Info("Adding controllers to manager")

--- a/pkg/operator/metrics/garden.go
+++ b/pkg/operator/metrics/garden.go
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+)
+
+const gardenSubsystem = "garden"
+
+type gardenCollector struct {
+	runtimeClient client.Reader
+	log           logr.Logger
+
+	gardenCondition *prometheus.Desc
+	gardenOperation *prometheus.Desc
+}
+
+func newGardenCollector(k8sClient client.Reader, log logr.Logger) *gardenCollector {
+	c := &gardenCollector{
+		runtimeClient: k8sClient,
+		log:           log,
+	}
+	c.setMetricDefinitions()
+	return c
+}
+
+func (c *gardenCollector) setMetricDefinitions() {
+	c.gardenCondition = prometheus.NewDesc(
+		prometheus.BuildFQName(metricPrefix, gardenSubsystem, "condition"),
+		"Condition state of the Garden.",
+		[]string{
+			"name",
+			"condition",
+			"status",
+		},
+		nil,
+	)
+	c.gardenOperation = prometheus.NewDesc(
+		prometheus.BuildFQName(metricPrefix, gardenSubsystem, "operation"),
+		"Condition state of the Garden.",
+		[]string{
+			"name",
+			"operation",
+		},
+		nil,
+	)
+}
+
+func (c *gardenCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.gardenCondition
+	ch <- c.gardenOperation
+}
+
+func (c *gardenCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx := context.Background()
+
+	gardenList := &operatorv1alpha1.GardenList{}
+	if err := c.runtimeClient.List(ctx, gardenList); err != nil {
+		c.log.Error(err, "Failed to list gardens")
+		return
+	}
+
+	for _, garden := range gardenList.Items {
+		c.collectConditionMetric(ch, &garden)
+		c.collectOperationMetric(ch, &garden)
+	}
+}
+
+func (c gardenCollector) collectConditionMetric(ch chan<- prometheus.Metric, garden *operatorv1alpha1.Garden) {
+	for _, condition := range garden.Status.Conditions {
+		if condition.Type == "" {
+			continue
+		}
+		for _, status := range []gardencorev1beta1.ConditionStatus{
+			gardencorev1beta1.ConditionFalse,
+			gardencorev1beta1.ConditionTrue,
+			gardencorev1beta1.ConditionProgressing,
+			gardencorev1beta1.ConditionUnknown,
+		} {
+			val := float64(0)
+			if condition.Status == status {
+				val = 1
+			}
+			ch <- prometheus.MustNewConstMetric(
+				c.gardenCondition,
+				prometheus.GaugeValue,
+				val,
+				[]string{
+					garden.Name,
+					string(condition.Type),
+					string(status),
+				}...,
+			)
+		}
+	}
+}
+
+func (c *gardenCollector) collectOperationMetric(ch chan<- prometheus.Metric, garden *operatorv1alpha1.Garden) {
+	if garden.Status.LastOperation == nil {
+		return
+	}
+	for _, typ := range []gardencorev1beta1.LastOperationType{
+		gardencorev1beta1.LastOperationTypeCreate,
+		gardencorev1beta1.LastOperationTypeReconcile,
+		gardencorev1beta1.LastOperationTypeDelete,
+		gardencorev1beta1.LastOperationTypeMigrate,
+		gardencorev1beta1.LastOperationTypeRestore,
+	} {
+		val := float64(0)
+		if garden.Status.LastOperation.Type == typ {
+			val = 1
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.gardenOperation,
+			prometheus.GaugeValue,
+			val,
+			[]string{
+				garden.Name,
+				string(typ),
+			}...,
+		)
+	}
+}

--- a/pkg/operator/metrics/garden.go
+++ b/pkg/operator/metrics/garden.go
@@ -47,7 +47,7 @@ func (c *gardenCollector) setMetricDefinitions() {
 	)
 	c.gardenOperation = prometheus.NewDesc(
 		prometheus.BuildFQName(metricPrefix, gardenSubsystem, "operation"),
-		"Condition state of the Garden.",
+		"LastOperation of the operator.",
 		[]string{
 			"name",
 			"operation",
@@ -113,8 +113,6 @@ func (c *gardenCollector) collectOperationMetric(ch chan<- prometheus.Metric, ga
 		gardencorev1beta1.LastOperationTypeCreate,
 		gardencorev1beta1.LastOperationTypeReconcile,
 		gardencorev1beta1.LastOperationTypeDelete,
-		gardencorev1beta1.LastOperationTypeMigrate,
-		gardencorev1beta1.LastOperationTypeRestore,
 	} {
 		val := float64(0)
 		if garden.Status.LastOperation.Type == typ {

--- a/pkg/operator/metrics/garden_test.go
+++ b/pkg/operator/metrics/garden_test.go
@@ -89,4 +89,18 @@ gardener_operator_garden_operation_succeeded{name="foo"} 1
 			testutil.CollectAndCompare(c, expected, "gardener_operator_garden_operation_succeeded"),
 		).To(Succeed())
 	})
+
+	It("should collect the metric for not succeeded gardens", func() {
+		garden.Status.LastOperation.State = gardencorev1beta1.LastOperationStateError
+		Expect(k8sClient.Status().Update(ctx, garden)).To(Succeed())
+
+		expected := strings.NewReader(`# HELP gardener_operator_garden_operation_succeeded Returns 1 if the last operation state is Succeeded.
+# TYPE gardener_operator_garden_operation_succeeded gauge
+gardener_operator_garden_operation_succeeded{name="foo"} 0
+`)
+
+		Expect(
+			testutil.CollectAndCompare(c, expected, "gardener_operator_garden_operation_succeeded"),
+		).To(Succeed())
+	})
 })

--- a/pkg/operator/metrics/garden_test.go
+++ b/pkg/operator/metrics/garden_test.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	operatorv1alpha1 "github.com/gardener/gardener/pkg/apis/operator/v1alpha1"
+)
+
+var _ = Describe("Garden metrics", func() {
+	var (
+		ctx       context.Context
+		k8sClient client.Client
+
+		c      prometheus.Collector
+		garden *operatorv1alpha1.Garden
+	)
+
+	BeforeEach(func() {
+		testScheme := runtime.NewScheme()
+		Expect(operatorv1alpha1.AddToScheme(testScheme)).To(Succeed())
+		k8sClient = fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithStatusSubresource(&operatorv1alpha1.Garden{}).
+			Build()
+
+		c = newGardenCollector(k8sClient, logr.Discard())
+
+		garden = &operatorv1alpha1.Garden{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		}
+		Expect(k8sClient.Create(ctx, garden)).To(Succeed())
+
+		garden.Status = operatorv1alpha1.GardenStatus{
+			LastOperation: &gardencorev1beta1.LastOperation{
+				Type: gardencorev1beta1.LastOperationTypeReconcile,
+			},
+			Conditions: []gardencorev1beta1.Condition{
+				{Type: operatorv1alpha1.RuntimeComponentsHealthy, Status: gardencorev1beta1.ConditionTrue},
+				{Type: operatorv1alpha1.VirtualComponentsHealthy, Status: gardencorev1beta1.ConditionFalse},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, garden)).To(Succeed())
+
+	})
+
+	It("should collect condition metrics", func() {
+		expected := strings.NewReader(`# HELP gardener_operator_garden_condition Condition state of the Garden.
+# TYPE gardener_operator_garden_condition gauge
+gardener_operator_garden_condition{condition="RuntimeComponentsHealthy",name="foo",status="False"} 0
+gardener_operator_garden_condition{condition="RuntimeComponentsHealthy",name="foo",status="Progressing"} 0
+gardener_operator_garden_condition{condition="RuntimeComponentsHealthy",name="foo",status="True"} 1
+gardener_operator_garden_condition{condition="RuntimeComponentsHealthy",name="foo",status="Unknown"} 0
+gardener_operator_garden_condition{condition="VirtualComponentsHealthy",name="foo",status="False"} 1
+gardener_operator_garden_condition{condition="VirtualComponentsHealthy",name="foo",status="Progressing"} 0
+gardener_operator_garden_condition{condition="VirtualComponentsHealthy",name="foo",status="True"} 0
+gardener_operator_garden_condition{condition="VirtualComponentsHealthy",name="foo",status="Unknown"} 0
+`)
+
+		Expect(
+			testutil.CollectAndCompare(c, expected, "gardener_operator_garden_condition"),
+		).To(Succeed())
+	})
+
+	It("should collect operation metrics", func() {
+		expected := strings.NewReader(`# HELP gardener_operator_garden_operation Condition state of the Garden.
+# TYPE gardener_operator_garden_operation gauge
+gardener_operator_garden_operation{name="foo",operation="Create"} 0
+gardener_operator_garden_operation{name="foo",operation="Delete"} 0
+gardener_operator_garden_operation{name="foo",operation="Migrate"} 0
+gardener_operator_garden_operation{name="foo",operation="Reconcile"} 1
+gardener_operator_garden_operation{name="foo",operation="Restore"} 0
+`)
+
+		Expect(
+			testutil.CollectAndCompare(c, expected, "gardener_operator_garden_operation"),
+		).To(Succeed())
+	})
+})

--- a/pkg/operator/metrics/garden_test.go
+++ b/pkg/operator/metrics/garden_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Garden metrics", func() {
 
 		garden.Status = operatorv1alpha1.GardenStatus{
 			LastOperation: &gardencorev1beta1.LastOperation{
-				Type: gardencorev1beta1.LastOperationTypeReconcile,
+				State: gardencorev1beta1.LastOperationStateSucceeded,
 			},
 			Conditions: []gardencorev1beta1.Condition{
 				{Type: operatorv1alpha1.RuntimeComponentsHealthy, Status: gardencorev1beta1.ConditionTrue},
@@ -79,18 +79,14 @@ gardener_operator_garden_condition{condition="VirtualComponentsHealthy",name="fo
 		).To(Succeed())
 	})
 
-	It("should collect operation metrics", func() {
-		expected := strings.NewReader(`# HELP gardener_operator_garden_operation Condition state of the Garden.
-# TYPE gardener_operator_garden_operation gauge
-gardener_operator_garden_operation{name="foo",operation="Create"} 0
-gardener_operator_garden_operation{name="foo",operation="Delete"} 0
-gardener_operator_garden_operation{name="foo",operation="Migrate"} 0
-gardener_operator_garden_operation{name="foo",operation="Reconcile"} 1
-gardener_operator_garden_operation{name="foo",operation="Restore"} 0
+	It("should collect operation succeeded metrics", func() {
+		expected := strings.NewReader(`# HELP gardener_operator_garden_operation_succeeded Returns 1 if the last operation state is Succeeded.
+# TYPE gardener_operator_garden_operation_succeeded gauge
+gardener_operator_garden_operation_succeeded{name="foo"} 1
 `)
 
 		Expect(
-			testutil.CollectAndCompare(c, expected, "gardener_operator_garden_operation"),
+			testutil.CollectAndCompare(c, expected, "gardener_operator_garden_operation_succeeded"),
 		).To(Succeed())
 	})
 })

--- a/pkg/operator/metrics/metrics.go
+++ b/pkg/operator/metrics/metrics.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	runtimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	metricPrefix = "gardener_operator"
+)
+
+type runnable struct {
+	gardenCollector *gardenCollector
+}
+
+// AddToManager adds the custom metrics collectors to the metrics registry. This is done "inside" a `manager.Runnable`,
+// because that guarantees that the cache informers are synced, before the metrics are added / scraped for the first
+// time.
+func AddToManager(_ context.Context, mgr manager.Manager) error {
+	k8sClient := mgr.GetClient()
+	return mgr.Add(&runnable{
+		gardenCollector: newGardenCollector(k8sClient, mgr.GetLogger().WithName("operator-metrics")),
+	})
+}
+
+func (r *runnable) Start(_ context.Context) error {
+	runtimemetrics.Registry.MustRegister(r.gardenCollector)
+	return nil
+}

--- a/pkg/operator/metrics/metrics_suite_test.go
+++ b/pkg/operator/metrics/metrics_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Metrics Suite")
+}

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -158,6 +158,7 @@ build:
             - pkg/operator/controller/garden/garden
             - pkg/operator/controller/garden/reference
             - pkg/operator/features
+            - pkg/operator/metrics
             - pkg/operator/webhook
             - pkg/operator/webhook/defaulting
             - pkg/operator/webhook/validation


### PR DESCRIPTION
This will not be published upstream, see: https://github.com/gardener/gardener/pull/10314

There is an ongoing effort to export CustomResourceMetrics via kube-state-metrics, which we want to switch to once that is available.

This change can be dropped when this is available, probably after at least v1.103

https://dev.azure.com/schwarzit/schwarzit.ske/_workitems/edit/656573
