### PR TITLE
`test-integration` should depend on `$(HELM)`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ test: $(REPORT_COLLECTOR) $(PROMTOOL) $(HELM) logcheck-symlinks
 	@cd $(LOGCHECK_DIR); go test -race -timeout=2m ./... | grep -v 'no test files'
 
 .PHONY: test-integration
-test-integration: $(REPORT_COLLECTOR) $(SETUP_ENVTEST)
+test-integration: $(REPORT_COLLECTOR) $(SETUP_ENVTEST) $(HELM)
 	@./hack/test-integration.sh ./test/integration/...
 
 .PHONY: test-cov


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug

**What this PR does / why we need it**:
The Gardener Makefile relies on a set of tools. The binaries of those tools are expected in the directory `hack/tools/bin/linux-<arch>`. 

If a tool binary is missing, the mechanics of the Make tool are used to trigger a download of the binary from the internet: There is a make target for each tool, which executes the download. All other make targets define dependencies on the "tool targets" for the tools they are using.

The Gardener integration tests use the `helm` tool, hence the corresponding make target `test-integration` should depend on the `$(HELM)` tool target, which will make sure the `helm` binary is available.

As far as I understand, the dependency on helm in the integration tests was introduced with this change: https://github.com/gardener/gardener/commit/83ab8143139aade74abdb12105a16fb5e1687da0
A new test is added in `test/integration/gardenlet/gardenlet/gardenlet_suite_test.go` that uses helm to setup a fake OCI registry.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
