### PR TITLE
Allow changing backup provider to S3

### DIFF
--- a/pkg/apis/core/validation/backupbucket.go
+++ b/pkg/apis/core/validation/backupbucket.go
@@ -58,7 +58,6 @@ func ValidateBackupBucketSpecUpdate(newSpec, oldSpec *core.BackupBucketSpec, fld
 
 	// TODO remove after we migrated the backup provider
 	if !(oldSpec.Provider.Type == "stackit" && newSpec.Provider.Type == "S3" && oldSpec.Provider.Region == newSpec.Provider.Region) {
-
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Provider, oldSpec.Provider, fldPath.Child("provider"))...)
 	}
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SeedName, oldSpec.SeedName, fldPath.Child("seedName"))...)

--- a/pkg/apis/core/validation/backupbucket.go
+++ b/pkg/apis/core/validation/backupbucket.go
@@ -56,7 +56,11 @@ func ValidateBackupBucketSpec(spec *core.BackupBucketSpec, fldPath *field.Path) 
 func ValidateBackupBucketSpecUpdate(newSpec, oldSpec *core.BackupBucketSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Provider, oldSpec.Provider, fldPath.Child("provider"))...)
+	// TODO remove after we migrated the backup provider
+	if !(oldSpec.Provider.Type == "stackit" && newSpec.Provider.Type == "S3" && oldSpec.Provider.Region == newSpec.Provider.Region) {
+
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Provider, oldSpec.Provider, fldPath.Child("provider"))...)
+	}
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SeedName, oldSpec.SeedName, fldPath.Child("seedName"))...)
 
 	return allErrs

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -296,7 +296,10 @@ func ValidateSeedSpecUpdate(newSeedSpec, oldSeedSpec *core.SeedSpec, fldPath *fi
 
 	if oldSeedSpec.Backup != nil {
 		if newSeedSpec.Backup != nil {
-			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup.Provider, oldSeedSpec.Backup.Provider, fldPath.Child("backup", "provider"))...)
+			// TODO remove after we migrated the backup provider
+			if !(oldSeedSpec.Backup.Provider == "stackit" && newSeedSpec.Backup.Provider == "S3") {
+				allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup.Provider, oldSeedSpec.Backup.Provider, fldPath.Child("backup", "provider"))...)
+			}
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup.Region, oldSeedSpec.Backup.Region, fldPath.Child("backup", "region"))...)
 		} else {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup, oldSeedSpec.Backup, fldPath.Child("backup"))...)

--- a/pkg/apis/extensions/validation/backupbucket.go
+++ b/pkg/apis/extensions/validation/backupbucket.go
@@ -65,7 +65,9 @@ func ValidateBackupBucketSpecUpdate(new, old *extensionsv1alpha1.BackupBucketSpe
 		return apivalidation.ValidateImmutableField(new, old, fldPath)
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
+	if !(old.Type == "stackit" && new.Type == "S3") {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
+	}
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Region, old.Region, fldPath.Child("region"))...)
 
 	return allErrs

--- a/pkg/apis/extensions/validation/backupentry.go
+++ b/pkg/apis/extensions/validation/backupentry.go
@@ -69,7 +69,9 @@ func ValidateBackupEntrySpecUpdate(new, old *extensionsv1alpha1.BackupEntrySpec,
 		return apivalidation.ValidateImmutableField(new, old, fldPath)
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
+	if !(old.Type == "stackit" && new.Type == "S3") {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
+	}
 
 	return allErrs
 }


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
We want to move to the backup-s3 provider because it supports customCa and means we have less code to maintain. The field is immutable. In our case it should be fine, because the stackit provider is essentially just S3.

As far as I can tell, the `BackupEntry` does not deny this change.

~~/hold I want to test the prerelease on ondemand~~ DONE