### PR TITLE
Allow to change `seedSpec.backup.region` for STACKIT:X region migration

### DIFF
--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -300,7 +300,8 @@ func ValidateSeedSpecUpdate(newSeedSpec, oldSeedSpec *core.SeedSpec, fldPath *fi
 			if !(oldSeedSpec.Backup.Provider == "stackit" && newSeedSpec.Backup.Provider == "S3") {
 				allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup.Provider, oldSeedSpec.Backup.Provider, fldPath.Child("backup", "provider"))...)
 			}
-			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup.Region, oldSeedSpec.Backup.Region, fldPath.Child("backup", "region"))...)
+			// TODO remove after STACKIT:X region have been migrated
+			// allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup.Region, oldSeedSpec.Backup.Region, fldPath.Child("backup", "region"))...)
 		} else {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSeedSpec.Backup, oldSeedSpec.Backup, fldPath.Child("backup"))...)
 		}

--- a/pkg/apis/core/validation/seed_test.go
+++ b/pkg/apis/core/validation/seed_test.go
@@ -1067,15 +1067,18 @@ var _ = Describe("Seed Validation Tests", func() {
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.nodes"),
 				"Detail": Equal(`field is immutable`),
-			}, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.backup.region"),
-				"Detail": Equal(`field is immutable`),
-			}, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.backup.provider"),
-				"Detail": Equal(`field is immutable`),
-			}))
+			},
+				// TODO: Remove after STACKIT:X PreProd region migration
+				//Fields{
+				//	"Type":   Equal(field.ErrorTypeInvalid),
+				//	"Field":  Equal("spec.backup.region"),
+				//	"Detail": Equal(`field is immutable`),
+				//},
+				Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("spec.backup.provider"),
+					"Detail": Equal(`field is immutable`),
+				}))
 		})
 
 		Context("#validateSeedBackupUpdate", func() {


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:

Backupbuckets on STACKIT:X QA were created in region `eu01` which is immutable. This PR allows the user to change the seed Configuration so we can delete & recreate backupbuckets and entries in the correct region for STACKIT:X which is `object-storage`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

