### PR TITLE
backupbucket: temporarily allow changing the region

### DIFF
--- a/pkg/apis/core/validation/backupbucket.go
+++ b/pkg/apis/core/validation/backupbucket.go
@@ -57,7 +57,8 @@ func ValidateBackupBucketSpecUpdate(newSpec, oldSpec *core.BackupBucketSpec, fld
 	allErrs := field.ErrorList{}
 
 	// TODO remove after we migrated the backup provider
-	if !(oldSpec.Provider.Type == "stackit" && newSpec.Provider.Type == "S3" && oldSpec.Provider.Region == newSpec.Provider.Region) {
+	// skip check if changing providers, or if the region changes
+	if !(oldSpec.Provider.Type == "stackit" && newSpec.Provider.Type == "S3") && (oldSpec.Provider.Region == newSpec.Provider.Region) {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.Provider, oldSpec.Provider, fldPath.Child("provider"))...)
 	}
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newSpec.SeedName, oldSpec.SeedName, fldPath.Child("seedName"))...)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area backup
/kind enhancement

**What this PR does / why we need it**:

We need to update the region name of several backupbuckets. However, that currently fails with the following error:

`BackupBucket.core.gardener.cloud "[...]" is invalid: spec.provider: Invalid value: core.BackupBucketProvider{Type:"S3", Region:"[...]"}: field is immutable Operation will be retried.`


**Special notes for your reviewer**:

Must also be ported to the v1.98 branch.