### PR TITLE
Set `insecure_skip_verify` to true for cadvisor and kubelet job

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/cadvisor.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/cadvisor.yaml
@@ -6,7 +6,7 @@ metrics_path: /metrics/cadvisor
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: {{.IsManagedSeed}}
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/kubelet.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/kubelet.yaml
@@ -4,7 +4,7 @@ scheme: https
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: {{.IsManagedSeed}}
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:

--- a/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs_test.go
@@ -122,7 +122,7 @@ metrics_path: /metrics/cadvisor
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: false
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:
@@ -183,7 +183,7 @@ scheme: https
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: false
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug

**What this PR does / why we need it**:

Since Prometheus Targets are all down due to [gardener#9716](https://github.com/gardener/gardener/pull/9716) in Gardener v1.96, we need to set insecure_skip_verify to true on cadvisor & kubelet scrape config.
    
This is only a temporary fix, it can be dropped whenever we have a long term solution, which would likely involve enabling server certificate bootstrap (instead of self signed certificates) for the kubelet
