### PR TITLE
Workaround: Gardener Node Agent deletes containerd drop-in

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component.go
@@ -16,7 +16,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate"
-	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -86,12 +85,6 @@ func (containerd) Config(_ components.Context) ([]extensionsv1alpha1.Unit, []ext
 		},
 	}
 
-	// Unit without content to trigger restart of containerd.service when CAs change.
-	containerdUnit := extensionsv1alpha1.Unit{
-		Name:      UnitName,
-		FilePaths: []string{rootcertificates.PathLocalSSLRootCerts},
-	}
-
 	monitorUnit := extensionsv1alpha1.Unit{
 		Name:    UnitNameMonitor,
 		Command: ptr.To(extensionsv1alpha1.CommandStart),
@@ -108,5 +101,5 @@ ExecStart=` + pathHealthMonitor),
 		FilePaths: []string{monitorFile.Path},
 	}
 
-	return append(logRotateUnits, containerdUnit, monitorUnit), append(logRotateFiles, monitorFile), nil
+	return append(logRotateUnits, monitorUnit), append(logRotateFiles, monitorFile), nil
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -28,11 +28,6 @@ var _ = Describe("Component", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 
-			containerdUnit := extensionsv1alpha1.Unit{
-				Name:      "containerd.service",
-				FilePaths: []string{"/var/lib/ca-certificates-local/ROOTcerts.crt"},
-			}
-
 			monitorUnit := extensionsv1alpha1.Unit{
 				Name:    "containerd-monitor.service",
 				Command: ptr.To(extensionsv1alpha1.CommandStart),
@@ -96,7 +91,7 @@ WantedBy=multi-user.target`),
 				},
 			}
 
-			Expect(units).To(ConsistOf(containerdUnit, monitorUnit, logrotateUnit, logrotateTimerUnit))
+			Expect(units).To(ConsistOf(monitorUnit, logrotateUnit, logrotateTimerUnit))
 			Expect(files).To(ConsistOf(monitorFile, logrotateConfigFile))
 		})
 	})

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -20,7 +20,6 @@ import (
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/containerd"
-	"github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates"
 	oscutils "github.com/gardener/gardener/pkg/component/extensions/operatingsystemconfig/utils"
 	"github.com/gardener/gardener/pkg/utils"
 )
@@ -113,7 +112,7 @@ EnvironmentFile=/etc/environment
 EnvironmentFile=-/var/lib/kubelet/extra_args
 ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/kubelet \
     ` + utils.Indent(strings.Join(cliFlags, " \\\n"), 4) + ` $KUBELET_EXTRA_ARGS`),
-		FilePaths: append(extensionsv1alpha1helper.FilePathsFrom(kubeletFiles), rootcertificates.PathLocalSSLRootCerts),
+		FilePaths: extensionsv1alpha1helper.FilePathsFrom(kubeletFiles),
 	}
 
 	return []extensionsv1alpha1.Unit{kubeletUnit}, kubeletFiles, nil

--- a/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -239,8 +239,10 @@ EnvironmentFile=/etc/environment
 EnvironmentFile=-/var/lib/kubelet/extra_args` + kubeletStartPre + `
 ExecStart=/opt/bin/kubelet \
     ` + utils.Indent(strings.Join(cliFlags, " \\\n"), 4) + ` $KUBELET_EXTRA_ARGS`),
-		FilePaths: []string{"/var/lib/kubelet/ca.crt", "/var/lib/kubelet/config/kubelet", "/opt/bin/kubelet", "/var/lib/ca-certificates-local/ROOTcerts.crt"},
+		FilePaths: []string{"/var/lib/kubelet/ca.crt", "/var/lib/kubelet/config/kubelet"},
 	}
+
+	unit.FilePaths = append(unit.FilePaths, "/opt/bin/kubelet")
 
 	return unit
 }

--- a/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/component_test.go
@@ -57,6 +57,7 @@ After=systemd-tmpfiles-setup.service clean-ca-certificates.service
 Before=sysinit.target kubelet.service
 ConditionPathIsReadWrite=/etc/ssl/certs
 ConditionPathIsReadWrite=/var/lib/ca-certificates-local
+ConditionPathExists=!/var/lib/kubelet/kubeconfig-real
 [Service]
 Type=oneshot
 ExecStart=/var/lib/ssl/update-local-ca-certificates.sh

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -110,8 +110,6 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/health-monitor.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
-            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
-            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/utils
             - pkg/component/garden/system/runtime
             - pkg/component/garden/system/virtual
@@ -1069,8 +1067,6 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
             - pkg/component/extensions/operatingsystemconfig/original/components/nodeagent
-            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
-            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail/templates/valitail-config.tpl.yaml
             - pkg/component/extensions/operatingsystemconfig/utils

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -709,8 +709,6 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
             - pkg/component/extensions/operatingsystemconfig/original/components/nodeagent
-            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
-            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail/templates/valitail-config.tpl.yaml
             - pkg/component/extensions/operatingsystemconfig/utils
@@ -1482,8 +1480,6 @@ build:
             - pkg/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/kubelet
             - pkg/component/extensions/operatingsystemconfig/original/components/nodeagent
-            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates
-            - pkg/component/extensions/operatingsystemconfig/original/components/rootcertificates/templates/scripts/update-local-ca-certificates.tpl.sh
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail
             - pkg/component/extensions/operatingsystemconfig/original/components/valitail/templates/valitail-config.tpl.yaml
             - pkg/component/extensions/operatingsystemconfig/utils


### PR DESCRIPTION
This reverts commit b88242d3f7d9e71818389843acf8d632bdff5fb9.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:

Reverting this as this will stop the gardener-node-agent from deleting our custom containerd system override.
This PR can potentially be dropped with v111 (if verified that it works) due to https://github.com/gardener/gardener/pull/11015

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
