### PR TITLE
:cherries: Cherry-Picks for `v1.113.0`

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -133,7 +133,7 @@ ctr images mount "` + image + `" "$tmp_dir"
 
 echo "> Copy gardener-node-agent binary to host (/opt/bin) and make it executable"
 mkdir -p "/opt/bin"
-cp -f "$tmp_dir/gardener-node-agent" "/opt/bin"
+cp -f "$tmp_dir/ko-app/gardener-node-agent" "/opt/bin"
 chmod +x "/opt/bin/gardener-node-agent"
 
 echo "> Bootstrap gardener-node-agent"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -17,7 +17,7 @@ ctr images mount "{{ .image }}" "$tmp_dir"
 
 echo "> Copy gardener-node-agent binary to host ({{ .binaryDirectory }}) and make it executable"
 mkdir -p "{{ .binaryDirectory }}"
-cp -f "$tmp_dir/gardener-node-agent" "{{ .binaryDirectory }}"
+cp -f "$tmp_dir/ko-app/gardener-node-agent" "{{ .binaryDirectory }}"
 chmod +x "{{ .binaryDirectory }}/gardener-node-agent"
 
 echo "> Bootstrap gardener-node-agent"

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -80,7 +80,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		Content: extensionsv1alpha1.FileContent{
 			ImageRef: &extensionsv1alpha1.FileContentImageRef{
 				Image:           ctx.Images[imagevector.ContainerImageNameGardenerNodeAgent].String(),
-				FilePathInImage: "/gardener-node-agent",
+				FilePathInImage: "/ko-app/gardener-node-agent",
 			},
 		},
 	})

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Component", func() {
 				Content: extensionsv1alpha1.FileContent{
 					ImageRef: &extensionsv1alpha1.FileContentImageRef{
 						Image:           "gardener-node-agent:v1",
-						FilePathInImage: "/gardener-node-agent",
+						FilePathInImage: "/ko-app/gardener-node-agent",
 					},
 				},
 			})

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -420,6 +420,7 @@ var _ = Describe("GardenerAPIServer", func() {
 								"--log-level=" + logLevel,
 								"--log-format=" + logFormat,
 								"--secure-port=8443",
+								"--shoot-admin-kubeconfig-max-expiration=4320h",
 								"--workload-identity-token-issuer=" + workloadIdentityIssuer,
 								"--workload-identity-signing-key-file=/etc/gardener-apiserver/workload-identity/signing/key.pem",
 								"--http2-max-streams-per-connection=1000",

--- a/pkg/component/gardener/apiserver/deployment.go
+++ b/pkg/component/gardener/apiserver/deployment.go
@@ -100,6 +100,8 @@ func (g *gardenerAPIServer) deployment(
 							"--log-level=" + g.values.LogLevel,
 							"--log-format=" + g.values.LogFormat,
 							fmt.Sprintf("--secure-port=%d", port),
+							// TODO: replace this hardcoded configuration with proper fields in the Garden API
+							"--shoot-admin-kubeconfig-max-expiration=4320h", // 6 months
 						},
 						Ports: []corev1.ContainerPort{{
 							Name:          "https",

--- a/pkg/component/gardener/controllermanager/configmaps.go
+++ b/pkg/component/gardener/controllermanager/configmaps.go
@@ -62,6 +62,8 @@ func (g *gardenerControllerManager) configMapControllerManagerConfig() (*corev1.
 			Project: &controllermanagerconfigv1alpha1.ProjectControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 				Quotas:          g.values.Quotas,
+				// TODO: replace this hardcoded configuration with proper fields in the Garden API
+				StaleExpirationTimeDays: ptr.To(6000),
 			},
 			SecretBinding: &controllermanagerconfigv1alpha1.SecretBindingControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),

--- a/pkg/component/gardener/controllermanager/controller_manager_test.go
+++ b/pkg/component/gardener/controllermanager/controller_manager_test.go
@@ -328,7 +328,7 @@ var _ = Describe("GardenerControllerManager", func() {
 				managedResourceSecretRuntime.Name = managedResourceRuntime.Spec.SecretRefs[0].Name
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())
 				cm := configMap(namespace, values)
-				Expect(cm.Name).To(Equal("gardener-controller-manager-config-960e3f19"))
+				Expect(cm.Name).To(Equal("gardener-controller-manager-config-625036ea"))
 				expectedRuntimeObjects = []client.Object{
 					cm,
 					serviceRuntime,
@@ -722,6 +722,8 @@ func configMap(namespace string, testValues Values) *corev1.ConfigMap {
 			Project: &controllermanagerconfigv1alpha1.ProjectControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 				Quotas:          testValues.Quotas,
+				// TODO: replace this hardcoded configuration with proper fields in the Garden API
+				StaleExpirationTimeDays: ptr.To(6000),
 			},
 			SecretBinding: &controllermanagerconfigv1alpha1.SecretBindingControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -623,6 +623,8 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 	}
 
 	if r.values.ResponsibilityMode == ForSource || r.values.ResponsibilityMode == ForSourceAndTarget {
+		config.SourceClientConnection.ClientConnectionConfiguration.QPS = 300
+		config.SourceClientConnection.ClientConnectionConfiguration.Burst = 500
 		config.Webhooks.CRDDeletionProtection.Enabled = true
 		config.Webhooks.ExtensionValidation.Enabled = true
 	}

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -473,6 +473,8 @@ var _ = Describe("ResourceManager", func() {
 					},
 					IngressControllerSelector: ingressControllerSelector,
 				}
+				config.SourceClientConnection.ClientConnectionConfiguration.QPS = 300
+				config.SourceClientConnection.ClientConnectionConfiguration.Burst = 500
 				config.Webhooks.CRDDeletionProtection.Enabled = true
 				config.Webhooks.ExtensionValidation.Enabled = true
 				config.Webhooks.SeccompProfile.Enabled = true

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/cadvisor.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/cadvisor.yaml
@@ -6,7 +6,7 @@ metrics_path: /metrics/cadvisor
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: {{.IsManagedSeed}}
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/kubelet.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/kubelet.yaml
@@ -4,7 +4,7 @@ scheme: https
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: {{.IsManagedSeed}}
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:

--- a/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs_test.go
@@ -122,7 +122,7 @@ metrics_path: /metrics/cadvisor
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: false
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:
@@ -183,7 +183,7 @@ scheme: https
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: false
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -55,6 +55,7 @@ func NewRuntimeGardenerResourceManager(
 
 	defaultValues := resourcemanager.Values{
 		ConcurrentSyncs:                      ptr.To(20),
+		AlwaysUpdate:                         ptr.To(true),
 		HealthSyncPeriod:                     &metav1.Duration{Duration: time.Minute},
 		Image:                                image.String(),
 		MaxConcurrentNetworkPolicyWorkers:    ptr.To(20),

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -58,6 +58,7 @@ var _ = Describe("ResourceManager", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resourceManager.GetValues()).To(Equal(resourcemanager.Values{
+				AlwaysUpdate:                         ptr.To(true),
 				ClusterIdentity:                      ptr.To("foo"),
 				ConcurrentSyncs:                      ptr.To(21),
 				HealthSyncPeriod:                     &metav1.Duration{Duration: time.Minute},


### PR DESCRIPTION
/kind enhancement

**Dropped Commits**
- [[ske-v1.88] cherrypick apiserver-proxy changes](https://github.com/stackitcloud/gardener/pull/127/commits/d2224e1a6fed0f207dd3a8f290f23201394bf6d4#diff-0cc11d98580d91dba21a3bd4c309844de9e80091c46f4e7ce4324ecd9d0aba51)
  - A new introduced `RemoveAPIServerProxyLegacyPort` now handles this
- [Allow configuring a maximum node count per shoot (https://github.com/stackitcloud/gardener/pull/124)](https://github.com/stackitcloud/gardener/pull/127/commits/5375f14515da314321f079e0261cd94491cd2707)
  - https://github.com/gardener/gardener/pull/11279 is included now
- https://github.com/stackitcloud/gardener/pull/125 
  - https://github.com/gardener/gardener/pull/11328 is included now