### PR TITLE
Revert "feat: allow using mcm with ko built image (#134)"

### DIFF
--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager.go
@@ -209,7 +209,8 @@ func (m *machineControllerManager) Deploy(ctx context.Context) error {
 					Name:            containerName,
 					Image:           m.values.Image,
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					Args: []string{
+					Command: []string{
+						"./machine-controller-manager",
 						"--control-kubeconfig=inClusterConfig",
 						"--machine-safety-overshooting-period=1m",
 						"--namespace=" + m.namespace,

--- a/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
+++ b/pkg/component/nodemanagement/machinecontrollermanager/machine_controller_manager_test.go
@@ -205,7 +205,8 @@ var _ = Describe("MachineControllerManager", func() {
 							Name:            "machine-controller-manager",
 							Image:           image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Args: []string{
+							Command: []string{
+								"./machine-controller-manager",
 								"--control-kubeconfig=inClusterConfig",
 								"--machine-safety-overshooting-period=1m",
 								"--namespace=" + namespace,


### PR DESCRIPTION
This reverts commit 9dba882ff1be100a5cae96a200f147de31ca60df.