### PR TITLE
v1.115.0 cherry-picks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardener
 
-go 1.24.0
+go 1.23.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/nodeinit_test.go
@@ -133,7 +133,7 @@ ctr images mount "` + image + `" "$tmp_dir"
 
 echo "> Copy gardener-node-agent binary to host (/opt/bin) and make it executable"
 mkdir -p "/opt/bin"
-cp -f "$tmp_dir/gardener-node-agent" "/opt/bin"
+cp -f "$tmp_dir/ko-app/gardener-node-agent" "/opt/bin"
 chmod +x "/opt/bin/gardener-node-agent"
 
 echo "> Bootstrap gardener-node-agent"

--- a/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
+++ b/pkg/component/extensions/operatingsystemconfig/nodeinit/templates/scripts/init.tpl.sh
@@ -17,7 +17,7 @@ ctr images mount "{{ .image }}" "$tmp_dir"
 
 echo "> Copy gardener-node-agent binary to host ({{ .binaryDirectory }}) and make it executable"
 mkdir -p "{{ .binaryDirectory }}"
-cp -f "$tmp_dir/gardener-node-agent" "{{ .binaryDirectory }}"
+cp -f "$tmp_dir/ko-app/gardener-node-agent" "{{ .binaryDirectory }}"
 chmod +x "{{ .binaryDirectory }}/gardener-node-agent"
 
 echo "> Bootstrap gardener-node-agent"

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component.go
@@ -80,7 +80,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 		Content: extensionsv1alpha1.FileContent{
 			ImageRef: &extensionsv1alpha1.FileContentImageRef{
 				Image:           ctx.Images[imagevector.ContainerImageNameGardenerNodeAgent].String(),
-				FilePathInImage: "/gardener-node-agent",
+				FilePathInImage: "/ko-app/gardener-node-agent",
 			},
 		},
 	})

--- a/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/nodeagent/component_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Component", func() {
 				Content: extensionsv1alpha1.FileContent{
 					ImageRef: &extensionsv1alpha1.FileContentImageRef{
 						Image:           "gardener-node-agent:v1",
-						FilePathInImage: "/gardener-node-agent",
+						FilePathInImage: "/ko-app/gardener-node-agent",
 					},
 				},
 			})

--- a/pkg/component/gardener/apiserver/apiserver_test.go
+++ b/pkg/component/gardener/apiserver/apiserver_test.go
@@ -336,6 +336,7 @@ var _ = Describe("GardenerAPIServer", func() {
 								"--log-level=" + logLevel,
 								"--log-format=" + logFormat,
 								"--secure-port=8443",
+								"--shoot-admin-kubeconfig-max-expiration=4320h",
 								"--goaway-chance=0.001500",
 								"--workload-identity-token-issuer=" + workloadIdentityIssuer,
 								"--workload-identity-signing-key-file=/etc/gardener-apiserver/workload-identity/signing/key.pem",

--- a/pkg/component/gardener/apiserver/deployment.go
+++ b/pkg/component/gardener/apiserver/deployment.go
@@ -53,6 +53,8 @@ func (g *gardenerAPIServer) deployment(
 		"--log-level=" + g.values.LogLevel,
 		"--log-format=" + g.values.LogFormat,
 		fmt.Sprintf("--secure-port=%d", port),
+		// TODO: replace this hardcoded configuration with proper fields in the Garden API
+		"--shoot-admin-kubeconfig-max-expiration=4320h", // 6 months
 	}
 
 	if g.values.GoAwayChance != nil {

--- a/pkg/component/gardener/controllermanager/configmaps.go
+++ b/pkg/component/gardener/controllermanager/configmaps.go
@@ -62,6 +62,8 @@ func (g *gardenerControllerManager) configMapControllerManagerConfig() (*corev1.
 			Project: &controllermanagerconfigv1alpha1.ProjectControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 				Quotas:          g.values.Quotas,
+				// TODO: replace this hardcoded configuration with proper fields in the Garden API
+				StaleExpirationTimeDays: ptr.To(6000),
 			},
 			SecretBinding: &controllermanagerconfigv1alpha1.SecretBindingControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),

--- a/pkg/component/gardener/controllermanager/controller_manager_test.go
+++ b/pkg/component/gardener/controllermanager/controller_manager_test.go
@@ -315,7 +315,7 @@ var _ = Describe("GardenerControllerManager", func() {
 				managedResourceSecretRuntime.Name = managedResourceRuntime.Spec.SecretRefs[0].Name
 				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretRuntime), managedResourceSecretRuntime)).To(Succeed())
 				cm := configMap(namespace, values)
-				Expect(cm.Name).To(Equal("gardener-controller-manager-config-960e3f19"))
+				Expect(cm.Name).To(Equal("gardener-controller-manager-config-625036ea"))
 				expectedRuntimeObjects = []client.Object{
 					cm,
 					podDisruptionBudget,
@@ -692,6 +692,8 @@ func configMap(namespace string, testValues Values) *corev1.ConfigMap {
 			Project: &controllermanagerconfigv1alpha1.ProjectControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),
 				Quotas:          testValues.Quotas,
+				// TODO: replace this hardcoded configuration with proper fields in the Garden API
+				StaleExpirationTimeDays: ptr.To(6000),
 			},
 			SecretBinding: &controllermanagerconfigv1alpha1.SecretBindingControllerConfiguration{
 				ConcurrentSyncs: ptr.To(20),

--- a/pkg/component/gardener/resourcemanager/resource_manager.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager.go
@@ -618,6 +618,8 @@ func (r *resourceManager) ensureConfigMap(ctx context.Context, configMap *corev1
 	}
 
 	if r.values.ResponsibilityMode == ForSource || r.values.ResponsibilityMode == ForSourceAndTarget {
+		config.SourceClientConnection.ClientConnectionConfiguration.QPS = 300
+		config.SourceClientConnection.ClientConnectionConfiguration.Burst = 500
 		config.Webhooks.CRDDeletionProtection.Enabled = true
 		config.Webhooks.ExtensionValidation.Enabled = true
 	}

--- a/pkg/component/gardener/resourcemanager/resource_manager_test.go
+++ b/pkg/component/gardener/resourcemanager/resource_manager_test.go
@@ -465,6 +465,8 @@ var _ = Describe("ResourceManager", func() {
 					},
 					IngressControllerSelector: ingressControllerSelector,
 				}
+				config.SourceClientConnection.ClientConnectionConfiguration.QPS = 300
+				config.SourceClientConnection.ClientConnectionConfiguration.Burst = 500
 				config.Webhooks.CRDDeletionProtection.Enabled = true
 				config.Webhooks.ExtensionValidation.Enabled = true
 				config.Webhooks.SeccompProfile.Enabled = true

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/cadvisor.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/cadvisor.yaml
@@ -6,7 +6,7 @@ metrics_path: /metrics/cadvisor
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: {{.IsManagedSeed}}
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:

--- a/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/kubelet.yaml
+++ b/pkg/component/observability/monitoring/prometheus/cache/assets/scrapeconfigs/kubelet.yaml
@@ -4,7 +4,7 @@ scheme: https
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: {{.IsManagedSeed}}
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:

--- a/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/cache/scrapeconfigs_test.go
@@ -122,7 +122,7 @@ metrics_path: /metrics/cadvisor
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: false
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:
@@ -183,7 +183,7 @@ scheme: https
 
 tls_config:
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  insecure_skip_verify: false
+  insecure_skip_verify: true
 bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 kubernetes_sd_configs:

--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -55,6 +55,7 @@ func NewRuntimeGardenerResourceManager(
 
 	defaultValues := resourcemanager.Values{
 		ConcurrentSyncs:                   ptr.To(20),
+		AlwaysUpdate:                      ptr.To(true),
 		HealthSyncPeriod:                  &metav1.Duration{Duration: time.Minute},
 		Image:                             image.String(),
 		MaxConcurrentNetworkPolicyWorkers: ptr.To(20),

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -58,6 +58,7 @@ var _ = Describe("ResourceManager", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resourceManager.GetValues()).To(Equal(resourcemanager.Values{
+				AlwaysUpdate:                      ptr.To(true),
 				ClusterIdentity:                   ptr.To("foo"),
 				ConcurrentSyncs:                   ptr.To(21),
 				HealthSyncPeriod:                  &metav1.Duration{Duration: time.Minute},

--- a/pkg/operator/controller/extension/required/runtime/add_test.go
+++ b/pkg/operator/controller/extension/required/runtime/add_test.go
@@ -116,7 +116,6 @@ var _ = Describe("Add", func() {
 
 				It("should return the expected extensions", func() {
 					Expect(mapperFunc(ctx, garden)).To(ConsistOf(
-						Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: infraExtension.Name}}),
 						Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: dnsExtension.Name}}),
 					))
 				})

--- a/pkg/utils/gardener/garden.go
+++ b/pkg/utils/gardener/garden.go
@@ -374,9 +374,10 @@ func IsServedByKubeAPIServer(resource string) bool {
 func ComputeRequiredExtensionsForGarden(garden *operatorv1alpha1.Garden) sets.Set[string] {
 	requiredExtensions := sets.New[string]()
 
-	if helper.GetETCDMainBackup(garden) != nil {
-		requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.BackupBucketResource, garden.Spec.VirtualCluster.ETCD.Main.Backup.Provider))
-	}
+	// TODO: reapply validation when STACKITSKE-830 is resolved
+	// if helper.GetETCDMainBackup(garden) != nil {
+	// 	requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.BackupBucketResource, garden.Spec.VirtualCluster.ETCD.Main.Backup.Provider))
+	// }
 
 	for _, provider := range helper.GetDNSProviders(garden) {
 		requiredExtensions.Insert(ExtensionsID(extensionsv1alpha1.DNSRecordResource, provider.Type))

--- a/pkg/utils/gardener/garden_test.go
+++ b/pkg/utils/gardener/garden_test.go
@@ -390,9 +390,7 @@ var _ = Describe("Garden", func() {
 				},
 			}
 
-			Expect(ComputeRequiredExtensionsForGarden(garden).UnsortedList()).To(ConsistOf(
-				"BackupBucket/local-infrastructure",
-			))
+			Expect(ComputeRequiredExtensionsForGarden(garden).UnsortedList()).To(BeEmpty())
 		})
 
 		It("should return required DNSRecord extension types", func() {
@@ -440,7 +438,6 @@ var _ = Describe("Garden", func() {
 			}
 
 			Expect(ComputeRequiredExtensionsForGarden(garden).UnsortedList()).To(ConsistOf(
-				"BackupBucket/local-infrastructure",
 				"DNSRecord/local-dns",
 				"Extension/local-extension-1",
 				"Extension/local-extension-2",

--- a/test/integration/operator/extension/required/runtime/runtime_test.go
+++ b/test/integration/operator/extension/required/runtime/runtime_test.go
@@ -175,10 +175,10 @@ var _ = Describe("Extension Required Runtime controller tests", Ordered, func() 
 	It("should report extensions as required after garden was created", func() {
 		Expect(testClient.Create(ctx, garden)).To(Succeed())
 
-		for _, ext := range []client.Object{providerExtension, dnsExtension} {
+		for _, ext := range []client.Object{dnsExtension} {
 			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(ext), ext)).To(Succeed())
-				return providerExtension.Status.Conditions
+				return dnsExtension.Status.Conditions
 			}).Should(ContainCondition(
 				OfType(operatorv1alpha1.ExtensionRequiredRuntime),
 				WithStatus(gardencorev1beta1.ConditionTrue),
@@ -259,15 +259,6 @@ var _ = Describe("Extension Required Runtime controller tests", Ordered, func() 
 			OfType(operatorv1alpha1.ExtensionRequiredRuntime),
 			WithStatus(gardencorev1beta1.ConditionFalse),
 			WithReason("ExtensionNotRequired"),
-		))
-
-		Consistently(func(g Gomega) []gardencorev1beta1.Condition {
-			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(providerExtension), providerExtension)).To(Succeed())
-			return providerExtension.Status.Conditions
-		}).Should(ContainCondition(
-			OfType(operatorv1alpha1.ExtensionRequiredRuntime),
-			WithStatus(gardencorev1beta1.ConditionTrue),
-			WithReason("ExtensionRequired"),
 		))
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR applies our fork changes to the Gardener 1.115 release.
