### PR TITLE
Revert "Enable AlwaysUpdate for resource manager targeting runtime cluster"

### DIFF
--- a/pkg/component/shared/resourcemanager.go
+++ b/pkg/component/shared/resourcemanager.go
@@ -39,7 +39,6 @@ import (
 func runtimeGardenerResourceManagerDefaultValues() resourcemanager.Values {
 	return resourcemanager.Values{
 		ConcurrentSyncs:                   ptr.To(20),
-		AlwaysUpdate:                      ptr.To(true),
 		HealthSyncPeriod:                  &metav1.Duration{Duration: time.Minute},
 		MaxConcurrentNetworkPolicyWorkers: ptr.To(20),
 		NetworkPolicyControllerIngressControllerSelector: &resourcemanagerconfigv1alpha1.IngressControllerSelector{

--- a/pkg/component/shared/resourcemanager_test.go
+++ b/pkg/component/shared/resourcemanager_test.go
@@ -58,7 +58,6 @@ var _ = Describe("ResourceManager", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resourceManager.GetValues()).To(Equal(resourcemanager.Values{
-				AlwaysUpdate:                      ptr.To(true),
 				ClusterIdentity:                   ptr.To("foo"),
 				ConcurrentSyncs:                   ptr.To(21),
 				HealthSyncPeriod:                  &metav1.Duration{Duration: time.Minute},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:

This reverts commit cdb3a8ac0af3fcfc44dd4b7987dae479e48312fe.

Replaced by improved kyverno policies with proper background scanning/mutating. This commit can be dropped along with its original commit when upgrading to g/g@v1.119.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/hold until verified in ondemand