### PR TITLE
Revert "Allow virtual cluster ETCd bucket name to be mutated"

### DIFF
--- a/pkg/apis/operator/v1alpha1/validation/garden.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden.go
@@ -137,10 +137,9 @@ func validateVirtualClusterUpdate(oldGarden, newGarden *operatorv1alpha1.Garden)
 	if oldVirtualCluster.ETCD != nil && oldVirtualCluster.ETCD.Main != nil && oldVirtualCluster.ETCD.Main.Backup != nil &&
 		newVirtualCluster.ETCD != nil && newVirtualCluster.ETCD.Main != nil {
 		fldBackup := fldPath.Child("etcd", "main", "backup")
-		// TODO: reapply validation when https://github.com/stackitcloud/ske-base/pull/3088 is rolled out
-		/*if newVirtualCluster.ETCD.Main.Backup != nil {
+		if newVirtualCluster.ETCD.Main.Backup != nil {
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldVirtualCluster.ETCD.Main.Backup.BucketName, newVirtualCluster.ETCD.Main.Backup.BucketName, fldBackup.Child("bucketName"))...)
-		}*/
+		}
 		if newVirtualCluster.ETCD.Main.Backup == nil {
 			allErrs = append(allErrs, field.Forbidden(fldBackup, "backup must not be deactivated if it was set before"))
 		}

--- a/pkg/apis/operator/v1alpha1/validation/garden_test.go
+++ b/pkg/apis/operator/v1alpha1/validation/garden_test.go
@@ -2459,58 +2459,54 @@ var _ = Describe("Validation Tests", func() {
 			})
 
 			Context("ETCD", func() {
-				/*
-					It("should not be possible to set the backup bucket name if it was unset initially", func() {
-						oldGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
-							Main: &operatorv1alpha1.ETCDMain{
-								Backup: &operatorv1alpha1.Backup{
-									Provider: "foo-provider",
-									ProviderConfig: &runtime.RawExtension{
-										Raw: []byte(`{"foo":"bar"}`),
-									},
+				It("should not be possible to set the backup bucket name if it was unset initially", func() {
+					oldGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
+						Main: &operatorv1alpha1.ETCDMain{
+							Backup: &operatorv1alpha1.Backup{
+								Provider: "foo-provider",
+								ProviderConfig: &runtime.RawExtension{
+									Raw: []byte(`{"foo":"bar"}`),
 								},
 							},
-						}
-						newGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
-							Main: &operatorv1alpha1.ETCDMain{
-								Backup: &operatorv1alpha1.Backup{
-									BucketName: ptr.To("foo-bucket"),
-									Provider:   "foo-provider",
-								},
+						},
+					}
+					newGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
+						Main: &operatorv1alpha1.ETCDMain{
+							Backup: &operatorv1alpha1.Backup{
+								BucketName: ptr.To("foo-bucket"),
+								Provider:   "foo-provider",
 							},
-						}
+						},
+					}
 
-						Expect(ValidateGardenUpdate(oldGarden, newGarden, extensions)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":  Equal(field.ErrorTypeInvalid),
-							"Field": Equal("spec.virtualCluster.etcd.main.backup.bucketName"),
-						}))))
-					})
-				*/
+					Expect(ValidateGardenUpdate(oldGarden, newGarden, extensions)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.virtualCluster.etcd.main.backup.bucketName"),
+					}))))
+				})
 
-				/*
-					It("should not be possible to delete the backup bucket name if it was set initially", func() {
-						oldGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
-							Main: &operatorv1alpha1.ETCDMain{
-								Backup: &operatorv1alpha1.Backup{
-									Provider:   "foo-provider",
-									BucketName: ptr.To("foo-bucket"),
-								},
+				It("should not be possible to delete the backup bucket name if it was set initially", func() {
+					oldGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
+						Main: &operatorv1alpha1.ETCDMain{
+							Backup: &operatorv1alpha1.Backup{
+								Provider:   "foo-provider",
+								BucketName: ptr.To("foo-bucket"),
 							},
-						}
-						newGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
-							Main: &operatorv1alpha1.ETCDMain{
-								Backup: &operatorv1alpha1.Backup{
-									Provider: "foo-provider",
-								},
+						},
+					}
+					newGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{
+						Main: &operatorv1alpha1.ETCDMain{
+							Backup: &operatorv1alpha1.Backup{
+								Provider: "foo-provider",
 							},
-						}
+						},
+					}
 
-						Expect(ValidateGardenUpdate(oldGarden, newGarden, extensions)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":  Equal(field.ErrorTypeInvalid),
-							"Field": Equal("spec.virtualCluster.etcd.main.backup.bucketName"),
-						}))))
-					})
-				*/
+					Expect(ValidateGardenUpdate(oldGarden, newGarden, extensions)).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.virtualCluster.etcd.main.backup.bucketName"),
+					}))))
+				})
 
 				It("should not be possible to delete the backup if it was set initially", func() {
 					oldGarden.Spec.VirtualCluster.ETCD = &operatorv1alpha1.ETCD{


### PR DESCRIPTION
This reverts commit 38e03514d0a3b52ec0883240997cebf271248d5d.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
This PR reverts https://github.com/stackitcloud/gardener/commit/38e03514d0a3b52ec0883240997cebf271248d5d as its not needed anymore.
We rolled out v1.120.1-ske-1 on every stage and migrated to the new `BackupBucket`.
