### PR TITLE
feat: disable project CreatedBy validation

### DIFF
--- a/pkg/apis/core/validation/project.go
+++ b/pkg/apis/core/validation/project.go
@@ -68,9 +68,6 @@ func ValidateProjectUpdate(newProject, oldProject *core.Project) field.ErrorList
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newProject.ObjectMeta, &oldProject.ObjectMeta, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateProjectWithOpts(newProject, opts)...)
 
-	if oldProject.Spec.CreatedBy != nil {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProject.Spec.CreatedBy, oldProject.Spec.CreatedBy, field.NewPath("spec", "createdBy"))...)
-	}
 	if oldProject.Spec.Namespace != nil {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProject.Spec.Namespace, oldProject.Spec.Namespace, field.NewPath("spec", "namespace"))...)
 	}

--- a/pkg/apis/core/validation/project_test.go
+++ b/pkg/apis/core/validation/project_test.go
@@ -645,30 +645,6 @@ var _ = Describe("Project Validation Tests", func() {
 			Entry("no change (same value)", ptr.To("garden-dev"), ptr.To("garden-dev"), BeEmpty()),
 		)
 
-		It("should forbid Project updates trying to change the createdBy field", func() {
-			newProject := prepareProjectForUpdate(project)
-			newProject.Spec.CreatedBy.Name = "some-other-user"
-
-			errorList := ValidateProjectUpdate(newProject, project)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.createdBy"),
-			}))))
-		})
-
-		It("should forbid Project updates trying to change the createdBy field", func() {
-			newProject := prepareProjectForUpdate(project)
-			newProject.Spec.CreatedBy.Name = "some-other-user"
-
-			errorList := ValidateProjectUpdate(newProject, project)
-
-			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.createdBy"),
-			}))))
-		})
-
 		It("should forbid Project updates trying to reset the owner field", func() {
 			newProject := prepareProjectForUpdate(project)
 			newProject.Spec.Owner = nil


### PR DESCRIPTION
/kind enhancement

Temp disable project `CreatedBy` validation to clean up personal email addresses.

Part of STACKITSKE-3326