### PR TITLE
systemdunitcheck: Do not report unhealthy status for a disabled unit that is in failed state

### DIFF
--- a/pkg/nodeagent/controller/systemdunitcheck/reconciler.go
+++ b/pkg/nodeagent/controller/systemdunitcheck/reconciler.go
@@ -168,7 +168,10 @@ func (r *Reconciler) checkUnits(ctx context.Context, units []unitInfo) (unhealth
 			}
 
 		case "failed":
-			unhealthyMessages = append(unhealthyMessages, fmt.Sprintf("%s: failed", unit.name))
+			// Only enabled units should be marked as erroring in case they are in a failed state.
+			if unit.enabled {
+				unhealthyMessages = append(unhealthyMessages, fmt.Sprintf("%s: failed", unit.name))
+			}
 
 		case "activating", "deactivating":
 			// Services configured with Restart=always/on-success cycle through "activating (auto-restart)"

--- a/test/integration/nodeagent/systemdunitcheck/systemdunitcheck_test.go
+++ b/test/integration/nodeagent/systemdunitcheck/systemdunitcheck_test.go
@@ -302,6 +302,28 @@ var _ = Describe("SystemdUnitCheck controller tests", func() {
 		})))
 	})
 
+	It("should not report unhealthy for a disabled unit that is in a failed state", func() {
+		writeOSC(&extensionsv1alpha1.OperatingSystemConfig{
+			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{
+				Units: []extensionsv1alpha1.Unit{
+					{Name: "optional.service", Enable: ptr.To(false)},
+				},
+			},
+		})
+
+		fakeDBus.AddUnitsToList(
+			systemddbus.UnitStatus{Name: "optional.service", ActiveState: "failed"},
+		)
+
+		Eventually(func(g Gomega) *corev1.NodeCondition {
+			return getNodeCondition(g)
+		}).Should(PointTo(MatchFields(IgnoreExtras, Fields{
+			"Type":   Equal(nodeagentconfigv1alpha1.ConditionTypeSystemdUnitsReady),
+			"Status": Equal(corev1.ConditionTrue),
+			"Reason": Equal("AllUnitsHealthy"),
+		})))
+	})
+
 	It("should also monitor gardener-node-agent's own units", func() {
 		writeOSC(&extensionsv1alpha1.OperatingSystemConfig{
 			Spec: extensionsv1alpha1.OperatingSystemConfigSpec{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area os
/kind bug

**What this PR does / why we need it**:

Cherry-pick of https://github.com/gardener/gardener/pull/14733 to unblock us from rolling out gardener v1.141.

Fixes a bug in https://github.com/gardener/gardener/pull/14496 in combination with https://github.com/gardener/gardener-extension-os-coreos/blob/0f3c67a060fa90771c10e9322fa09d5757e37b55/pkg/controller/operatingsystemconfig/actuator.go#L191-L194.

**Which issue(s) this PR fixes**:
Part of https://jira.schwarz/browse/STACKITSKE-7357

**Special notes for your reviewer**:

/hold
let's verify this fix on an ondemand first

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
