### PR TITLE
Add a jitter to logrotate

### DIFF
--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -48,10 +48,11 @@ WantedBy=multi-user.target`),
 				Command: new(extensionsv1alpha1.CommandStart),
 				Enable:  new(true),
 				Content: new(`[Unit]
-Description=Log Rotation at each 10 minutes
+Description=Log Rotation once a day
 [Timer]
-OnCalendar=*:0/10
+OnCalendar=daily
 AccuracySec=1min
+RandomizedDelaySec=4h
 Persistent=true
 [Install]
 WantedBy=multi-user.target`),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate.go
@@ -53,10 +53,11 @@ WantedBy=multi-user.target`),
 		Command: new(extensionsv1alpha1.CommandStart),
 		Enable:  new(true),
 		Content: new(`[Unit]
-Description=Log Rotation at each 10 minutes
+Description=Log Rotation once a day
 [Timer]
-OnCalendar=*:0/10
+OnCalendar=daily
 AccuracySec=1min
+RandomizedDelaySec=4h
 Persistent=true
 [Install]
 WantedBy=multi-user.target`),

--- a/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
+++ b/pkg/component/extensions/operatingsystemconfig/original/components/containerd/logrotate/logrotate_test.go
@@ -48,10 +48,11 @@ WantedBy=multi-user.target`),
 					Command: new(extensionsv1alpha1.CommandStart),
 					Enable:  new(true),
 					Content: new(`[Unit]
-Description=Log Rotation at each 10 minutes
+Description=Log Rotation once a day
 [Timer]
-OnCalendar=*:0/10
+OnCalendar=daily
 AccuracySec=1min
+RandomizedDelaySec=4h
 Persistent=true
 [Install]
 WantedBy=multi-user.target`),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Currently all nodes run logrotate at `0:00 UTC` at the same time, which causes high capacity utilization.
With the current configuration, it runs 144 times a day but only rotates the logs at 0:00 UTC, which is pointless.
This PR changes the it in order to run once a day with a jitter of 4 hours.

**Which issue(s) this PR fixes**:
ref https://github.com/gardener/gardener/issues/15149

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```