### PR TITLE
Skip etcdEncryptionKeyRotation when cluster is hibernated

### DIFF
--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -691,7 +691,8 @@ func computeCredentialsToRotationResults(log logr.Logger, shoot *gardencorev1bet
 	}
 
 	if etcdEncryptionKeyRotationEnabled &&
-		etcdEncryptionKeyRotationPassedRotationPeriod(shoot, now.Time, *shoot.Spec.Maintenance.AutoRotation.Credentials.ETCDEncryptionKey.RotationPeriod) {
+		etcdEncryptionKeyRotationPassedRotationPeriod(shoot, now.Time, *shoot.Spec.Maintenance.AutoRotation.Credentials.ETCDEncryptionKey.RotationPeriod) &&
+		!v1beta1helper.HibernationIsEnabled(shoot) {
 		if len(etcdEncryptionKeyRotationPhase) == 0 || etcdEncryptionKeyRotationPhase == gardencorev1beta1.RotationCompleted {
 			reason := "Automatic rotation of etcd encryption key configured"
 			log.Info("ETCD Encryption key will be rotated", "reason", reason)


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind bug

**What this PR does / why we need it**:
etcd key rotation requires the cluster to be awake. So we just skip it if the cluster is hibernated during maintenance.

**Which issue(s) this PR fixes**:
ref https://github.com/gardener/gardener/issues/15200

**Special notes for your reviewer**:
/cc @stackitcloud/ske-gardener 
